### PR TITLE
Add P3 local control

### DIFF
--- a/.github/workflows/hacs.yml
+++ b/.github/workflows/hacs.yml
@@ -2,7 +2,10 @@ name: HACS Action
 
 on: # yamllint disable-line rule:truthy
   push:
+    branches: [main]
   pull_request:
+    types: [opened, synchronize]
+    branches: [main]
   schedule:
     - cron: "0 0 * * *"
   workflow_dispatch:

--- a/.github/workflows/hassfest.yml
+++ b/.github/workflows/hassfest.yml
@@ -2,7 +2,10 @@ name: Validate with hassfest
 
 on: # yamllint disable-line rule:truthy
   push:
+    branches: [main]
   pull_request:
+    types: [opened, synchronize]
+    branches: [main]
   schedule:
     - cron: "0 0 * * *"
   workflow_dispatch:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,9 +8,10 @@ env:
 # yamllint disable-line rule:truthy
 on:
   push:
+    branches: [main]
   pull_request:
     types: [opened, synchronize]
-    branches: main
+    branches: [main]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -36,7 +37,7 @@ jobs:
       - name: Generate partial Python venv restore key
         id: generate-python-key
         run: >-
-          echo "key=${{ env.KEY_PREFIX }}-${{ env.CACHE_VERSION }}-${{
+          echo "key=${{ env.KEY_PREFIX }}-${{ env.CACHE_VERSION }}-${{ github.ref_name }}-${{
             hashFiles('pyproject.toml', 'requirements_test_pre_commit.txt',
           'requirements.txt') }}" >>
           $GITHUB_OUTPUT
@@ -48,6 +49,8 @@ jobs:
           key: >-
             ${{ runner.os }}-${{ steps.python.outputs.python-version }}-${{
             steps.generate-python-key.outputs.key }}
+          restore-keys: |
+            ${{ runner.os }}-${{ steps.python.outputs.python-version }}-${{ env.KEY_PREFIX }}-${{ env.CACHE_VERSION }}-
       - name: Create Python virtual environment
         if: steps.cache-venv.outputs.cache-hit != 'true'
         run: |
@@ -58,7 +61,7 @@ jobs:
       - name: Generate pre-commit restore key
         id: generate-pre-commit-key
         run: >-
-          echo "key=pre-commit-${{ env.CACHE_VERSION }}-${{
+          echo "key=pre-commit-${{ env.CACHE_VERSION }}-${{ github.ref_name }}-${{
             hashFiles('.pre-commit-config.yaml') }}" >> $GITHUB_OUTPUT
       - name: Restore pre-commit environment
         id: cache-precommit
@@ -67,6 +70,8 @@ jobs:
           path: ${{ env.PRE_COMMIT_CACHE }}
           key: >-
             ${{ runner.os }}-${{ steps.generate-pre-commit-key.outputs.key }}
+          restore-keys: |
+            ${{ runner.os }}-pre-commit-${{ env.CACHE_VERSION }}-
       - name: Install pre-commit dependencies
         if: steps.cache-precommit.outputs.cache-hit != 'true'
         run: |
@@ -95,6 +100,8 @@ jobs:
           fail-on-cache-miss: true
           key: ${{ runner.os }}-${{ steps.python.outputs.python-version }}-${{
             needs.prepare-base.outputs.python-key }}
+          restore-keys: |
+            ${{ runner.os }}-${{ steps.python.outputs.python-version }}-${{ env.KEY_PREFIX }}-${{ env.CACHE_VERSION }}-
       - name: Restore pre-commit environment
         id: cache-precommit
         uses: actions/cache@v5
@@ -102,6 +109,8 @@ jobs:
           path: ${{ env.PRE_COMMIT_CACHE }}
           fail-on-cache-miss: true
           key: ${{ runner.os }}-${{ needs.prepare-base.outputs.pre-commit-key }}
+          restore-keys: |
+            ${{ runner.os }}-pre-commit-${{ env.CACHE_VERSION }}-
       - name: Register ruff problem matcher
         run: |
           echo "::add-matcher::.github/workflows/matchers/ruff.json"
@@ -132,6 +141,8 @@ jobs:
           fail-on-cache-miss: true
           key: ${{ runner.os }}-${{ steps.python.outputs.python-version }}-${{
             needs.prepare-base.outputs.python-key }}
+          restore-keys: |
+            ${{ runner.os }}-${{ steps.python.outputs.python-version }}-${{ env.KEY_PREFIX }}-${{ env.CACHE_VERSION }}-
       - name: Restore pre-commit environment
         id: cache-precommit
         uses: actions/cache@v5
@@ -139,6 +150,8 @@ jobs:
           path: ${{ env.PRE_COMMIT_CACHE }}
           fail-on-cache-miss: true
           key: ${{ runner.os }}-${{ needs.prepare-base.outputs.pre-commit-key }}
+          restore-keys: |
+            ${{ runner.os }}-pre-commit-${{ env.CACHE_VERSION }}-
       - name: Run black checks
         run: |
           . venv/bin/activate
@@ -166,6 +179,8 @@ jobs:
           fail-on-cache-miss: true
           key: ${{ runner.os }}-${{ steps.python.outputs.python-version }}-${{
             needs.prepare-base.outputs.python-key }}
+          restore-keys: |
+            ${{ runner.os }}-${{ steps.python.outputs.python-version }}-${{ env.KEY_PREFIX }}-${{ env.CACHE_VERSION }}-
       - name: Restore pre-commit environment
         id: cache-precommit
         uses: actions/cache@v5
@@ -173,6 +188,8 @@ jobs:
           path: ${{ env.PRE_COMMIT_CACHE }}
           fail-on-cache-miss: true
           key: ${{ runner.os }}-${{ needs.prepare-base.outputs.pre-commit-key }}
+          restore-keys: |
+            ${{ runner.os }}-pre-commit-${{ env.CACHE_VERSION }}-
       - name: Register pylint problem matcher
         run: |
           echo "::add-matcher::.github/workflows/matchers/pylint.json"
@@ -203,6 +220,8 @@ jobs:
           fail-on-cache-miss: true
           key: ${{ runner.os }}-${{ steps.python.outputs.python-version }}-${{
             needs.prepare-base.outputs.python-key }}
+          restore-keys: |
+            ${{ runner.os }}-${{ steps.python.outputs.python-version }}-${{ env.KEY_PREFIX }}-${{ env.CACHE_VERSION }}-
       - name: Restore pre-commit environment
         id: cache-precommit
         uses: actions/cache@v5
@@ -210,6 +229,8 @@ jobs:
           path: ${{ env.PRE_COMMIT_CACHE }}
           fail-on-cache-miss: true
           key: ${{ runner.os }}-${{ needs.prepare-base.outputs.pre-commit-key }}
+          restore-keys: |
+            ${{ runner.os }}-pre-commit-${{ env.CACHE_VERSION }}-
       - name: Register mypy problem matcher
         run: |
           echo "::add-matcher::.github/workflows/matchers/mypy.json"
@@ -240,6 +261,8 @@ jobs:
           fail-on-cache-miss: true
           key: ${{ runner.os }}-${{ steps.python.outputs.python-version }}-${{
             needs.prepare-base.outputs.python-key }}
+          restore-keys: |
+            ${{ runner.os }}-${{ steps.python.outputs.python-version }}-${{ env.KEY_PREFIX }}-${{ env.CACHE_VERSION }}-
       - name: Restore pre-commit environment
         id: cache-precommit
         uses: actions/cache@v5
@@ -247,6 +270,8 @@ jobs:
           path: ${{ env.PRE_COMMIT_CACHE }}
           fail-on-cache-miss: true
           key: ${{ runner.os }}-${{ needs.prepare-base.outputs.pre-commit-key }}
+          restore-keys: |
+            ${{ runner.os }}-pre-commit-${{ env.CACHE_VERSION }}-
 
       - name: Register yamllint problem matcher
         run: |
@@ -304,6 +329,8 @@ jobs:
           fail-on-cache-miss: true
           key: ${{ runner.os }}-${{ steps.python.outputs.python-version }}-${{
             needs.prepare-base.outputs.python-key }}
+          restore-keys: |
+            ${{ runner.os }}-${{ steps.python.outputs.python-version }}-${{ env.KEY_PREFIX }}-${{ env.CACHE_VERSION }}-
       - name: Run tests
         run: |
           . venv/bin/activate

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,7 @@
 name: Test & Linting
 
 env:
-  DEFAULT_PYTHON: "3.11"
+  DEFAULT_PYTHON: "3.12"
   PRE_COMMIT_CACHE: ~/.cache/pre-commit
   KEY_PREFIX: base-venv
   CACHE_VERSION: 1
@@ -26,10 +26,10 @@ jobs:
       pre-commit-key: ${{ steps.generate-pre-commit-key.outputs.key }}
     steps:
       - name: Check out code from GitHub
-        uses: actions/checkout@v3.5.2
+        uses: actions/checkout@v6
       - name: Set up Python ${{ env.DEFAULT_PYTHON }}
         id: python
-        uses: actions/setup-python@v4.6.0
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ env.DEFAULT_PYTHON }}
           check-latest: true
@@ -42,7 +42,7 @@ jobs:
           $GITHUB_OUTPUT
       - name: Restore Python virtual environment
         id: cache-venv
-        uses: actions/cache@v4.3.0
+        uses: actions/cache@v5
         with:
           path: venv
           key: >-
@@ -62,7 +62,7 @@ jobs:
             hashFiles('.pre-commit-config.yaml') }}" >> $GITHUB_OUTPUT
       - name: Restore pre-commit environment
         id: cache-precommit
-        uses: actions/cache@v4.3.0
+        uses: actions/cache@v5
         with:
           path: ${{ env.PRE_COMMIT_CACHE }}
           key: >-
@@ -80,16 +80,16 @@ jobs:
     needs: prepare-base
     steps:
       - name: Check out code from GitHub
-        uses: actions/checkout@v3.5.2
+        uses: actions/checkout@v6
       - name: Set up Python ${{ env.DEFAULT_PYTHON }}
         id: python
-        uses: actions/setup-python@v4.6.0
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ env.DEFAULT_PYTHON }}
           check-latest: true
       - name: Restore Python virtual environment
         id: cache-venv
-        uses: actions/cache@v4.3.0
+        uses: actions/cache@v5
         with:
           path: venv
           fail-on-cache-miss: true
@@ -97,7 +97,7 @@ jobs:
             needs.prepare-base.outputs.python-key }}
       - name: Restore pre-commit environment
         id: cache-precommit
-        uses: actions/cache@v4.3.0
+        uses: actions/cache@v5
         with:
           path: ${{ env.PRE_COMMIT_CACHE }}
           fail-on-cache-miss: true
@@ -117,16 +117,16 @@ jobs:
     needs: prepare-base
     steps:
       - name: Check out code from GitHub
-        uses: actions/checkout@v3.5.2
+        uses: actions/checkout@v6
       - name: Set up Python ${{ env.DEFAULT_PYTHON }}
         id: python
-        uses: actions/setup-python@v4.6.0
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ env.DEFAULT_PYTHON }}
           check-latest: true
       - name: Restore Python virtual environment
         id: cache-venv
-        uses: actions/cache@v4.3.0
+        uses: actions/cache@v5
         with:
           path: venv
           fail-on-cache-miss: true
@@ -134,7 +134,7 @@ jobs:
             needs.prepare-base.outputs.python-key }}
       - name: Restore pre-commit environment
         id: cache-precommit
-        uses: actions/cache@v4.3.0
+        uses: actions/cache@v5
         with:
           path: ${{ env.PRE_COMMIT_CACHE }}
           fail-on-cache-miss: true
@@ -151,16 +151,16 @@ jobs:
     needs: prepare-base
     steps:
       - name: Check out code from GitHub
-        uses: actions/checkout@v3.5.2
+        uses: actions/checkout@v6
       - name: Set up Python ${{ env.DEFAULT_PYTHON }}
         id: python
-        uses: actions/setup-python@v4.6.0
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ env.DEFAULT_PYTHON }}
           check-latest: true
       - name: Restore Python virtual environment
         id: cache-venv
-        uses: actions/cache@v4.3.0
+        uses: actions/cache@v5
         with:
           path: venv
           fail-on-cache-miss: true
@@ -168,7 +168,7 @@ jobs:
             needs.prepare-base.outputs.python-key }}
       - name: Restore pre-commit environment
         id: cache-precommit
-        uses: actions/cache@v4.3.0
+        uses: actions/cache@v5
         with:
           path: ${{ env.PRE_COMMIT_CACHE }}
           fail-on-cache-miss: true
@@ -188,16 +188,16 @@ jobs:
     needs: prepare-base
     steps:
       - name: Check out code from GitHub
-        uses: actions/checkout@v3.5.2
+        uses: actions/checkout@v6
       - name: Set up Python ${{ env.DEFAULT_PYTHON }}
         id: python
-        uses: actions/setup-python@v4.6.0
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ env.DEFAULT_PYTHON }}
           check-latest: true
       - name: Restore Python virtual environment
         id: cache-venv
-        uses: actions/cache@v4.3.0
+        uses: actions/cache@v5
         with:
           path: venv
           fail-on-cache-miss: true
@@ -205,7 +205,7 @@ jobs:
             needs.prepare-base.outputs.python-key }}
       - name: Restore pre-commit environment
         id: cache-precommit
-        uses: actions/cache@v4.3.0
+        uses: actions/cache@v5
         with:
           path: ${{ env.PRE_COMMIT_CACHE }}
           fail-on-cache-miss: true
@@ -225,16 +225,16 @@ jobs:
     needs: prepare-base
     steps:
       - name: Check out code from GitHub
-        uses: actions/checkout@v3.5.2
+        uses: actions/checkout@v6
       - name: Set up Python ${{ env.DEFAULT_PYTHON }}
         id: python
-        uses: actions/setup-python@v4.6.0
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ env.DEFAULT_PYTHON }}
           check-latest: true
       - name: Restore Python virtual environment
         id: cache-venv
-        uses: actions/cache@v4.3.0
+        uses: actions/cache@v5
         with:
           path: venv
           fail-on-cache-miss: true
@@ -242,7 +242,7 @@ jobs:
             needs.prepare-base.outputs.python-key }}
       - name: Restore pre-commit environment
         id: cache-precommit
-        uses: actions/cache@v4.3.0
+        uses: actions/cache@v5
         with:
           path: ${{ env.PRE_COMMIT_CACHE }}
           fail-on-cache-miss: true
@@ -289,16 +289,16 @@ jobs:
     needs: prepare-base
     steps:
       - name: Check out code from GitHub
-        uses: actions/checkout@v3.5.2
+        uses: actions/checkout@v6
       - name: Set up Python ${{ env.DEFAULT_PYTHON }}
         id: python
-        uses: actions/setup-python@v4.6.0
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ env.DEFAULT_PYTHON }}
           check-latest: true
       - name: Restore Python virtual environment
         id: cache-venv
-        uses: actions/cache@v4.3.0
+        uses: actions/cache@v5
         with:
           path: venv
           fail-on-cache-miss: true

--- a/.gitignore
+++ b/.gitignore
@@ -176,3 +176,5 @@ pyrightconfig.json
 # End of https://www.toptal.com/developers/gitignore/api/python
 
 config/*
+scripts/*
+custom_components/hacs

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,7 @@ repos:
     hooks:
       - id: prettier
   - repo: https://github.com/psf/black
-    rev: 26.3.1
+    rev: 26.5.1
     hooks:
       - id: black
         args:

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -23,5 +23,6 @@
   "python.testing.pytestEnabled": true,
   "editor.formatOnType": true,
   "python.testing.pytestArgs": ["."],
-  "python.linting.pylintCategorySeverity.refactor": "Warning"
+  "python.linting.pylintCategorySeverity.refactor": "Warning",
+  "python-envs.defaultEnvManager": "ms-python.python:system"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+# v1.3.0
+
+### Added
+
+- **Legacy P3 local API support.** P3 units can now be connected directly over your local network instead of the deprecated Powervault cloud API. During setup, select "Legacy P3" and enter your unit's local IP address. The integration validates the connection before saving.
+- **Automatic migration for existing P3 users.** Existing config entries are migrated to schema version 2. After upgrading, Home Assistant will prompt you to confirm your model and (for P3 owners) enter your unit's local IP address. You many need to manually reload the integration after this step.
+- **Configurable polling interval for Legacy P3.** A new **Configure** option (available via `Settings > Devices & Services`) lets you set the polling interval for P3 units between 10 and 60 seconds (default 30 s). Changes take effect immediately without restarting Home Assistant.
+- **Today's energy totals from local chart data.** The P3 local path now fetches intraday chart data to calculate today's cumulative energy totals (kWh) for all channels, with last-known-value carry-forward to handle gaps in the data stream.
+
+### Changed
+
+- Config flow now starts with a model selector step (Legacy P3 / Newer Powervault) rather than going directly to the API key screen.
+- `iot_class` for P3 entries is effectively `local_polling`; the cloud path is unchanged.
+- The reauth flow now asks users to identify their model and, for P3 owners, to provide a local IP address instead of re-entering API credentials.
+- Bump [powervaultpy](https://pypi.org/project/powervaultpy/) version to v1.1.3.
+
 # v1.2.5
 
 - Fix power sensor state class and add last_reset for HA Energy Card compatibility

--- a/README.md
+++ b/README.md
@@ -35,3 +35,19 @@ This integration can be installed directly via HACS. To install:
 **⚠ WARNING: Changing battery status**
 
 _IMPORTANT_ Changing the battery status will override any schedule you have have configured in the Powervault portal. The override sets the battery to that status for the next 24hrs. Only change the status if you are controlling it using Home Assistant only and don't want to use the scheduler in the Powervault portal
+
+## Polling interval (Legacy P3 only)
+
+P3 units communicate over your local network, so the integration can poll much more frequently than the cloud API. The default is **30 seconds**, and you can adjust this between **10 and 60 seconds** via the integration's **Configure** button in `Settings > Devices & Services`.
+
+> [!WARNING] > **Avoid setting the polling interval too low without configuring the recorder.**
+> Every poll produces a new state for each Powervault sensor. At 10-second intervals that is up to **8,640 state changes per sensor per day**. Be aware this will rapidly inflate your database. Before reducing the interval below the default, consider either:
+>
+> - Excluding the Powervault entities from the recorder in your `configuration.yaml`:
+>   ```yaml
+>   recorder:
+>     exclude:
+>       entity_globs:
+>         - sensor.powervault_*
+>   ```
+> - Or only including the specific sensors you actually need in long-term history.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # Home Assistant Powervault
 
+> [!WARNING] > **Action required if upgrading from a previous version.**
+> Powervault have sunset the legacy cloud API for P3 units. After upgrading this integration, Home Assistant will mark it as requiring reconfiguration and you **must** complete the steps below before it will resume working.
+>
+> - **P3 owners:** you will be asked to confirm your model and enter the local IP address of your unit. Ensure your Powervault P3 is reachable on your local network before proceeding.
+> - **P4/P5 owners:** you will be asked to confirm your model. Your existing API key remains valid and no other changes are needed.
+
 ![installation_badge](https://img.shields.io/badge/dynamic/json?color=41BDF5&logo=home-assistant&label=integration%20usage&suffix=%20installs&cacheSeconds=15600&url=https://analytics.home-assistant.io/custom_integrations.json&query=$.powervault.total)
 
 This custom component for Home Assistant allows you to monitor the status of your Powervault P3, P4 or P5 battery. This uses the _paid_ API offered by Powervault. To obtain an API key, you first need to contact Powervault directly and pay for access. This integration is useless without it.

--- a/custom_components/powervault/__init__.py
+++ b/custom_components/powervault/__init__.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import logging
+from datetime import datetime as dt
 from datetime import timedelta
+from zoneinfo import ZoneInfo
 
 import requests
 from homeassistant.config_entries import ConfigEntry
@@ -17,6 +19,8 @@ from powervaultpy.powervault import ServerError
 from .const import (
     CONF_IP_ADDRESS,
     CONF_MODEL,
+    CONF_POLL_INTERVAL,
+    DEFAULT_POLL_INTERVAL,
     DOMAIN,
     MODEL_LEGACY_P3,
     MODEL_UNKNOWN,
@@ -42,7 +46,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     if model == MODEL_LEGACY_P3:
         local_ip = entry.data[CONF_IP_ADDRESS]
-        client = PowerVault("")
+        client = PowerVault(local_ip=local_ip)
         unit_id = None
         base_info = await hass.async_add_executor_job(
             _fetch_base_info_legacy, client, local_ip
@@ -66,12 +70,19 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         hass, client, unit_id, runtime_data, local_ip=local_ip
     )
 
+    if local_ip:
+        poll_interval = int(
+            entry.options.get(CONF_POLL_INTERVAL, DEFAULT_POLL_INTERVAL)
+        )
+    else:
+        poll_interval = UPDATE_INTERVAL
+
     coordinator = DataUpdateCoordinator(
         hass,
         _LOGGER,
         name="Powervault site",
         update_method=manager.async_update_data,
-        update_interval=timedelta(seconds=UPDATE_INTERVAL),
+        update_interval=timedelta(seconds=poll_interval),
     )
 
     await coordinator.async_config_entry_first_refresh()
@@ -81,6 +92,18 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = runtime_data
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+
+    if local_ip:
+
+        async def _options_updated(
+            _hass: HomeAssistant, updated_entry: ConfigEntry
+        ) -> None:
+            new_interval = int(
+                updated_entry.options.get(CONF_POLL_INTERVAL, DEFAULT_POLL_INTERVAL)
+            )
+            coordinator.update_interval = timedelta(seconds=new_interval)
+
+        entry.async_on_unload(entry.add_update_listener(_options_updated))
 
     return True
 
@@ -126,8 +149,8 @@ def _fetch_base_info(client: PowerVault, unit_id: str) -> PowervaultBaseInfo:
     return _call_base_info(client, unit_id)
 
 
-def _fetch_base_info_legacy(client: PowerVault, local_ip: str) -> PowervaultBaseInfo:
-    uid = client.get_unit_id(local_ip)
+def _fetch_base_info_legacy(client: PowerVault, _local_ip: str) -> PowervaultBaseInfo:
+    uid = client.get_unit_id()
     return PowervaultBaseInfo(id=uid, model="Powervault P3", eprom_id="")
 
 
@@ -216,50 +239,253 @@ def _fetch_powervault_data(  # pylint: disable=too-many-branches
 ) -> PowervaultData:
     """Process and update powervault data."""
     if local_ip:
-        return _fetch_powervault_data_legacy(client, local_ip)
+        return _fetch_powervault_data_legacy(client)
     return _fetch_powervault_data_cloud(client, unit_id)  # type: ignore[arg-type]
 
 
-def _fetch_powervault_data_legacy(client: PowerVault, local_ip: str) -> PowervaultData:
+def _fetch_powervault_data_legacy(  # pylint: disable=too-many-locals,too-many-statements
+    client: PowerVault,
+) -> PowervaultData:
     """Fetch data from a legacy P3 Powervault unit via the local REST API."""
-    data = client.get_data(local_ip=local_ip)
+    data = client.get_data(None)
 
-    _LOGGER.info(f"Local data: {data}")
+    _LOGGER.debug(f"Local data: {data}")
 
-    if not data or len(data) == 0 or "instant_soc" not in data[0]:
+    if not data or len(data) == 0:
         raise ServerError(
-            "Failed to get data from Powervault local API. Missing data from response."
+            "Failed to get data from Powervault local API. Empty response."
         )
+
+    # Local API returns a list of {measurement, value, ...} objects — flatten to a dict.
+    # Entries with None values are excluded so .get() fallbacks of 0 apply cleanly.
+    telemetry = {
+        item["measurement"]: item["value"]
+        for item in data
+        if item.get("value") is not None
+    }
+
+    _LOGGER.debug(f"Telemetry: {telemetry}")
+
+    if "socUsable" not in telemetry:
+        raise ServerError(
+            "Failed to get data from Powervault local API. Missing expected measurements."
+        )
+
+    # Fetch today's historical chart data to derive energy totals.
+    # Midnight..end-of-day in local time, converted to UTC-aware datetimes.
+
+    local_tz = ZoneInfo("Europe/London")
+    now_local = dt.now(local_tz)
+    today_midnight = dt(
+        now_local.year, now_local.month, now_local.day, 0, 0, 0, tzinfo=local_tz
+    )
+    today_end = dt(
+        now_local.year, now_local.month, now_local.day, 23, 59, 59, tzinfo=local_tz
+    )
+    _LOGGER.debug(f"Today midnight/end: {today_midnight}/{today_end}")
+
+    chart_totals: dict[str, float] = {}
+    try:
+        chart_data = client.get_chart_data(today_midnight, today_end)
+        # Debnug log the chart data, but only the first 5 entries
+        _LOGGER.debug(f"Chart data: {chart_data[:5]}")
+        # chart_data is a list of lists — each inner list is a group of
+        # {measurement, value, timestamp, ...} objects sharing the same timestamp.
+        # For each 30-second sample, extract the three power measurements then
+        # compute per-sample energy flows (kWh = W × 30s / 3600s / 1000).
+        interval_wh = 30 / 3600  # 30-second sample interval → Wh per sample
+
+        acc: dict[str, float] = {
+            "batteryInputFromGrid": 0.0,
+            "batteryInputFromSolar": 0.0,
+            "batteryOutputConsumedByHome": 0.0,
+            "batteryOutputExported": 0.0,
+            "solarConsumedByHome": 0.0,
+            "solarExported": 0.0,
+            "solarGenerated": 0.0,
+            "gridConsumedByHome": 0.0,
+            "homeConsumed": 0.0,
+        }
+
+        # Carry the last known value for each power channel so that groups
+        # which only contain a subset of measurements still contribute correctly.
+        last_grid_w: float = 0.0
+        last_battery_w: float = 0.0
+        last_solar_w: float = 0.0
+
+        for timestamp_group in chart_data:
+            measurements: dict[str, float] = {
+                item["measurement"]: item["value"]
+                for item in timestamp_group
+                if item.get("measurement") is not None and item.get("value") is not None
+            }
+
+            last_grid_w = measurements.get("gridPower", last_grid_w)
+            last_battery_w = measurements.get("batteryPower", last_battery_w)
+            last_solar_w = measurements.get("aux1Power", last_solar_w)
+
+            grid_w = last_grid_w
+            battery_w = last_battery_w
+            solar_w = last_solar_w
+
+            # Signed convention:
+            # gridPower:    positive = importing, negative = exporting
+            # batteryPower: negative = discharging, positive = charging
+            # aux1Power:    negative = generating, positive = aux load
+            grid_import_w = max(grid_w, 0.0)
+            grid_export_w = max(-grid_w, 0.0)
+            battery_discharge_w = max(-battery_w, 0.0)
+            battery_charge_w = max(battery_w, 0.0)
+            solar_gen_w = max(-solar_w, 0.0)
+
+            # Solar allocation (solar-first priority):
+            # Solar covers home load first, then battery charge, then grid export.
+            solar_remaining = solar_gen_w
+            home_from_solar = min(
+                solar_remaining,
+                max(
+                    0.0,
+                    solar_gen_w
+                    + battery_discharge_w
+                    + grid_import_w
+                    - battery_charge_w,
+                ),
+            )
+            solar_remaining -= home_from_solar
+            battery_from_solar = min(solar_remaining, battery_charge_w)
+            solar_remaining -= battery_from_solar
+            solar_exported_w = min(solar_remaining, grid_export_w)
+
+            # Battery charge source: remaining charge after solar covered
+            battery_from_grid = max(0.0, battery_charge_w - battery_from_solar)
+
+            # Battery discharge allocation: home first, grid export second
+            battery_to_home = min(
+                battery_discharge_w,
+                max(
+                    0.0,
+                    battery_discharge_w
+                    + solar_gen_w
+                    + grid_import_w
+                    - battery_charge_w
+                    - grid_export_w,
+                ),
+            )
+            battery_exported_w = max(0.0, battery_discharge_w - battery_to_home)
+
+            # Home consumption
+            home_w = (
+                grid_import_w
+                + battery_discharge_w
+                + solar_gen_w
+                - battery_charge_w
+                - grid_export_w
+            )
+
+            acc["batteryInputFromGrid"] += battery_from_grid * interval_wh
+            acc["batteryInputFromSolar"] += battery_from_solar * interval_wh
+            acc["batteryOutputConsumedByHome"] += battery_to_home * interval_wh
+            acc["batteryOutputExported"] += battery_exported_w * interval_wh
+            acc["solarConsumedByHome"] += home_from_solar * interval_wh
+            acc["solarExported"] += solar_exported_w * interval_wh
+            acc["solarGenerated"] += solar_gen_w * interval_wh
+            acc["gridConsumedByHome"] += (
+                grid_import_w * interval_wh
+            )  # includes battery charging from grid
+            acc["homeConsumed"] += max(home_w, 0.0) * interval_wh
+
+        chart_totals = {k: round(v, 3) for k, v in acc.items()}
+        _LOGGER.debug(f"Chart totals: {chart_totals}")
+
+        # Get the min and max times for the chart data and convert them to human-readable strings
+        chart_min_time = chart_data[0][0]["timestamp"]
+        chart_max_time = chart_data[-1][0]["timestamp"]
+        chart_min_time = dt.fromtimestamp(chart_min_time, local_tz)
+        chart_max_time = dt.fromtimestamp(chart_max_time, local_tz)
+        _LOGGER.debug("Chart min/max times: %s/%s", chart_min_time, chart_max_time)
+
+    except Exception as err:  # pylint: disable=broad-except
+        _LOGGER.warning(f"Failed to fetch chart data for totals: {err}")
 
     battery_state = "UNKNOWN"
     try:
-        battery_state = client.get_battery_state(local_ip=local_ip)
+        battery_state = client.get_battery_state(None)
     except Exception as err:  # pylint: disable=broad-except
         _LOGGER.error(f"Failed to get battery state: {err}")
         _LOGGER.error(
             "Missing battery state indicates there's no schedule available and no overrides in place. Setting value to UNKNOWN"
         )
 
+    # Sign convention: positive gridPower = importing; negative batteryPower = discharging;
+    # aux1Power (solar) is negative when generating.
+    grid_power = telemetry.get("gridPower", 0)
+    battery_power = telemetry.get("batteryPower", 0)
+    solar_power = telemetry.get("aux1Power", 0)
+
+    # Derived instant values (in W)
+    instant_solar_gen_w = max(-solar_power, 0.0)
+    instant_battery_discharge_w = max(-battery_power, 0.0)
+    instant_battery_charge_w = max(battery_power, 0.0)
+    instant_grid_import_w = max(grid_power, 0.0)
+    instant_grid_export_w = max(-grid_power, 0.0)
+
+    # home demand = all sources flowing into the home
+    instant_demand_w = max(
+        instant_grid_import_w
+        + instant_battery_discharge_w
+        + instant_solar_gen_w
+        - instant_battery_charge_w,
+        0.0,
+    )
+
+    # Solar-first instant breakdown (mirrors the chart allocation logic)
+    sol_rem = instant_solar_gen_w
+    inst_solar_to_home = min(sol_rem, instant_demand_w)
+    sol_rem -= inst_solar_to_home
+    inst_solar_to_battery = min(sol_rem, instant_battery_charge_w)
+    sol_rem -= inst_solar_to_battery
+    inst_solar_exported = min(sol_rem, instant_grid_export_w)
+
+    inst_battery_from_grid = max(0.0, instant_battery_charge_w - inst_solar_to_battery)
+    inst_battery_to_home = min(
+        instant_battery_discharge_w,
+        max(0.0, instant_demand_w - inst_solar_to_home),
+    )
+    inst_battery_exported = max(0.0, instant_battery_discharge_w - inst_battery_to_home)
+
+    # All instant fields are stored in mW — sensor.py divides by 1000 to display W.
+    milli = 1000
+
     return PowervaultData(
-        charge=data[0]["instant_soc"],
-        batteryInputFromGrid=data[0]["batteryInputFromGrid"],
-        batteryInputFromSolar=data[0]["batteryInputFromSolar"],
-        batteryOutputConsumedByHome=data[0]["batteryOutputConsumedByHome"],
-        batteryOutputExported=data[0]["batteryOutputExported"],
-        homeConsumed=data[0]["homeConsumed"],
-        gridConsumedByHome=data[0]["gridConsumedByHome"],
-        solarConsumedByHome=data[0]["solarConsumedByHome"],
-        solarExported=data[0]["solarExported"],
-        instant_battery=data[0]["instant_battery"],
-        instant_demand=data[0]["instant_demand"],
-        instant_grid=data[0]["instant_grid"],
-        solarGenerated=data[0]["solarGenerated"],
-        solarConsumption=data[0]["solarConsumption"],
-        instant_solar=(
-            data[0]["instant_solar"] if data[0]["instant_solar"] > 10000 else 0
-        ),
+        charge=telemetry.get("socUsable", 0),
+        batteryInputFromGrid=inst_battery_from_grid * milli,
+        batteryInputFromSolar=inst_solar_to_battery * milli,
+        batteryOutputConsumedByHome=inst_battery_to_home * milli,
+        batteryOutputExported=inst_battery_exported * milli,
+        homeConsumed=instant_demand_w * milli,
+        gridConsumedByHome=instant_grid_import_w * milli,
+        solarConsumedByHome=inst_solar_to_home * milli,
+        solarExported=inst_solar_exported * milli,
+        instant_battery=battery_power * milli * -1,
+        instant_demand=instant_demand_w * milli * -1,
+        instant_grid=grid_power * milli,
+        solarGenerated=instant_solar_gen_w * milli,
+        solarConsumption=inst_solar_to_home * milli,
+        instant_solar=instant_solar_gen_w * milli,
         battery_state=battery_state,
-        totals={},
+        totals={
+            "batteryInputFromGrid": chart_totals.get("batteryInputFromGrid", 0),
+            "batteryInputFromSolar": chart_totals.get("batteryInputFromSolar", 0),
+            "batteryOutputConsumedByHome": chart_totals.get(
+                "batteryOutputConsumedByHome", 0
+            ),
+            "batteryOutputExported": chart_totals.get("batteryOutputExported", 0),
+            "gridConsumedByHome": chart_totals.get("gridConsumedByHome", 0),
+            "solarGenerated": chart_totals.get("solarGenerated", 0),
+            "solarConsumedByHome": chart_totals.get("solarConsumedByHome", 0),
+            "solarExported": chart_totals.get("solarExported", 0),
+            "homeConsumed": chart_totals.get("homeConsumed", 0),
+        },
     )
 
 

--- a/custom_components/powervault/__init__.py
+++ b/custom_components/powervault/__init__.py
@@ -9,11 +9,20 @@ import requests
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from powervaultpy import PowerVault
 from powervaultpy.powervault import ServerError
 
-from .const import DOMAIN, POWERVAULT_COORDINATOR, UPDATE_INTERVAL
+from .const import (
+    CONF_IP_ADDRESS,
+    CONF_MODEL,
+    DOMAIN,
+    MODEL_LEGACY_P3,
+    MODEL_UNKNOWN,
+    POWERVAULT_COORDINATOR,
+    UPDATE_INTERVAL,
+)
 from .models import PowervaultBaseInfo, PowervaultData, PowervaultRuntimeData
 
 _LOGGER = logging.getLogger(__name__)
@@ -23,13 +32,27 @@ PLATFORMS: list[Platform] = [Platform.SENSOR, Platform.SELECT]
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Powervault from a config entry."""
     hass.data.setdefault(DOMAIN, {})
-    api_key = entry.data["api_key"]
-    unit_id = entry.data["unit_id"]
-    client = PowerVault(api_key)
+
+    if (model := entry.data.get(CONF_MODEL, MODEL_UNKNOWN)) == MODEL_UNKNOWN:
+        raise ConfigEntryAuthFailed(
+            "Powervault model not configured. Please reconfigure this integration."
+        )
 
     http_session = requests.Session()
 
-    base_info = await hass.async_add_executor_job(_fetch_base_info, client, unit_id)
+    if model == MODEL_LEGACY_P3:
+        local_ip = entry.data[CONF_IP_ADDRESS]
+        client = PowerVault("")
+        unit_id = None
+        base_info = await hass.async_add_executor_job(
+            _fetch_base_info_legacy, client, local_ip
+        )
+    else:
+        api_key = entry.data["api_key"]
+        unit_id = entry.data["unit_id"]
+        local_ip = None
+        client = PowerVault(api_key)
+        base_info = await hass.async_add_executor_job(_fetch_base_info, client, unit_id)
 
     runtime_data = PowervaultRuntimeData(
         api_changed=False,
@@ -39,7 +62,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         api_instance=client,
     )
 
-    manager = PowervaultDataManager(hass, client, unit_id, runtime_data)
+    manager = PowervaultDataManager(
+        hass, client, unit_id, runtime_data, local_ip=local_ip
+    )
 
     coordinator = DataUpdateCoordinator(
         hass,
@@ -60,6 +85,33 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return True
 
 
+async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
+    """Migrate old config entry to current version."""
+    _LOGGER.debug(
+        "Migrating Powervault config entry from version %s", config_entry.version
+    )
+
+    if config_entry.version == 1:
+        # v1 entries predate the model field. We cannot determine from stored data
+        # alone whether this is a P3 or a newer unit, so we stamp "unknown".
+        # async_setup_entry will raise ConfigEntryAuthFailed which triggers a reauth
+        # flow that asks the user to identify their model and (for P3) enter their IP.
+        hass.config_entries.async_update_entry(
+            config_entry,
+            data={**config_entry.data, CONF_MODEL: MODEL_UNKNOWN},
+            version=2,
+        )
+        _LOGGER.info(
+            "Migrated Powervault config entry to version 2; user must confirm model"
+        )
+        return True
+
+    _LOGGER.error(
+        "Cannot migrate Powervault config entry from version %s", config_entry.version
+    )
+    return False
+
+
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
@@ -72,6 +124,11 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 def _fetch_base_info(client: PowerVault, unit_id: str) -> PowervaultBaseInfo:
     return _call_base_info(client, unit_id)
+
+
+def _fetch_base_info_legacy(client: PowerVault, local_ip: str) -> PowervaultBaseInfo:
+    uid = client.get_unit_id(local_ip)
+    return PowervaultBaseInfo(id=uid, model="Powervault P3", eprom_id="")
 
 
 def _call_base_info(client: PowerVault, unit_id: str) -> PowervaultBaseInfo:
@@ -117,16 +174,18 @@ def get_kwh(data: dict) -> dict:
 class PowervaultDataManager:  # pylint: disable=too-few-public-methods
     """Class to manager powervault data."""
 
-    def __init__(
+    def __init__(  # pylint: disable=too-many-arguments
         self,
         hass: HomeAssistant,
         client: PowerVault,
-        unit_id: str,
+        unit_id: str | None,
         runtime_data: PowervaultRuntimeData,
+        local_ip: str | None = None,
     ) -> None:
         """Init the data manager."""
         self.hass = hass
         self.unit_id = unit_id
+        self.local_ip = local_ip
         self.runtime_data = runtime_data
         self.client = client
 
@@ -142,7 +201,9 @@ class PowervaultDataManager:  # pylint: disable=too-few-public-methods
         _LOGGER.debug("Updating data")
         for _ in range(2):
             try:
-                data = _fetch_powervault_data(self.client, self.unit_id)
+                data = _fetch_powervault_data(
+                    self.client, self.unit_id, local_ip=self.local_ip
+                )
             except ServerError as err:
                 raise UpdateFailed("Unable to fetch data from powervault") from err
 
@@ -151,6 +212,58 @@ class PowervaultDataManager:  # pylint: disable=too-few-public-methods
 
 
 def _fetch_powervault_data(  # pylint: disable=too-many-branches
+    client: PowerVault, unit_id: str | None, local_ip: str | None = None
+) -> PowervaultData:
+    """Process and update powervault data."""
+    if local_ip:
+        return _fetch_powervault_data_legacy(client, local_ip)
+    return _fetch_powervault_data_cloud(client, unit_id)  # type: ignore[arg-type]
+
+
+def _fetch_powervault_data_legacy(client: PowerVault, local_ip: str) -> PowervaultData:
+    """Fetch data from a legacy P3 Powervault unit via the local REST API."""
+    data = client.get_data(local_ip=local_ip)
+
+    _LOGGER.info(f"Local data: {data}")
+
+    if not data or len(data) == 0 or "instant_soc" not in data[0]:
+        raise ServerError(
+            "Failed to get data from Powervault local API. Missing data from response."
+        )
+
+    battery_state = "UNKNOWN"
+    try:
+        battery_state = client.get_battery_state(local_ip=local_ip)
+    except Exception as err:  # pylint: disable=broad-except
+        _LOGGER.error(f"Failed to get battery state: {err}")
+        _LOGGER.error(
+            "Missing battery state indicates there's no schedule available and no overrides in place. Setting value to UNKNOWN"
+        )
+
+    return PowervaultData(
+        charge=data[0]["instant_soc"],
+        batteryInputFromGrid=data[0]["batteryInputFromGrid"],
+        batteryInputFromSolar=data[0]["batteryInputFromSolar"],
+        batteryOutputConsumedByHome=data[0]["batteryOutputConsumedByHome"],
+        batteryOutputExported=data[0]["batteryOutputExported"],
+        homeConsumed=data[0]["homeConsumed"],
+        gridConsumedByHome=data[0]["gridConsumedByHome"],
+        solarConsumedByHome=data[0]["solarConsumedByHome"],
+        solarExported=data[0]["solarExported"],
+        instant_battery=data[0]["instant_battery"],
+        instant_demand=data[0]["instant_demand"],
+        instant_grid=data[0]["instant_grid"],
+        solarGenerated=data[0]["solarGenerated"],
+        solarConsumption=data[0]["solarConsumption"],
+        instant_solar=(
+            data[0]["instant_solar"] if data[0]["instant_solar"] > 10000 else 0
+        ),
+        battery_state=battery_state,
+        totals={},
+    )
+
+
+def _fetch_powervault_data_cloud(  # pylint: disable=too-many-branches
     client: PowerVault, unit_id: str
 ) -> PowervaultData:
     """Process and update powervault data."""

--- a/custom_components/powervault/config_flow.py
+++ b/custom_components/powervault/config_flow.py
@@ -14,13 +14,34 @@ from homeassistant.helpers.selector import selector
 from powervaultpy import PowerVault
 from powervaultpy.powervault import RequestError, ServerError
 
-from .const import DOMAIN
+from .const import CONF_IP_ADDRESS, CONF_MODEL, DOMAIN, MODEL_LEGACY_P3, MODEL_NEWER
 
 _LOGGER = logging.getLogger(__name__)
+
+STEP_MODEL_DATA_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_MODEL): selector(
+            {
+                "select": {
+                    "options": [
+                        {"value": MODEL_LEGACY_P3, "label": "Legacy P3"},
+                        {"value": MODEL_NEWER, "label": "Newer Powervault"},
+                    ]
+                }
+            }
+        ),
+    }
+)
 
 STEP_USER_DATA_SCHEMA = vol.Schema(
     {
         vol.Required("api_key"): str,
+    }
+)
+
+STEP_LEGACY_UNIT_DATA_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_IP_ADDRESS): str,
     }
 )
 
@@ -51,10 +72,6 @@ async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str,
     except ServerError as exc:
         raise CannotConnect from exc
 
-    # If you cannot connect:
-    # throw CannotConnect
-    # If the authentication is wrong:
-    # InvalidAuth
     units_ = []
     for unit in units:
         units_.append(unit["id"])
@@ -63,35 +80,132 @@ async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str,
     return {"units": units_, "account_id": account_id}
 
 
+async def validate_legacy_unit(hass: HomeAssistant, ip_address: str) -> None:
+    """Validate connection to a legacy P3 Powervault unit via the health endpoint."""
+    client = PowerVault("")
+    try:
+        response = await hass.async_add_executor_job(client.get_health, ip_address)
+    except (RequestError, ServerError) as exc:
+        raise CannotConnect from exc
+
+    if response != {"status": "ok"}:
+        raise CannotConnect
+
+
 class PowervaultConfigFlow(ConfigFlow, domain=DOMAIN):  # type: ignore[call-arg]
     """Handle a config flow for Powervault."""
 
-    VERSION = 1
+    VERSION = 2
     unit_id: str
     unit_name: str
     account_info: dict[str, Any]
     api_key: str
+    model: str
 
-    async def async_step_pick_unit(
+    async def async_step_reauth(
+        self, _user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Handle re-authentication triggered when the stored model is unknown."""
+        return await self.async_step_reauth_model()
+
+    async def async_step_reauth_model(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
-        """Handle the initial step."""
+        """Ask the user to identify their Powervault model."""
         if user_input is not None:
-            # Save the picked unit id
-            self.unit_id = user_input["unit_id"]
-            self.unit_name = user_input["unit_name"]
-
-            # Now we can create the entity
-
-            return self.async_create_entry(
-                title=f"Powervault - {self.unit_name}",
-                data={"api_key": self.api_key, "unit_id": self.unit_id},
+            self.model = user_input[CONF_MODEL]
+            if self.model == MODEL_LEGACY_P3:
+                return await self.async_step_reauth_legacy()
+            # Newer unit — existing api_key / unit_id remain valid.
+            entry = self.hass.config_entries.async_get_entry(self.context["entry_id"])
+            self.hass.config_entries.async_update_entry(
+                entry,
+                data={**entry.data, CONF_MODEL: MODEL_NEWER},
             )
+            return self.async_abort(reason="reauth_successful")
+
+        return self.async_show_form(
+            step_id="reauth_model",
+            data_schema=STEP_MODEL_DATA_SCHEMA,
+        )
+
+    async def async_step_reauth_legacy(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Ask for the IP address of the legacy P3 unit."""
+        errors: dict[str, str] = {}
+        if user_input is not None:
+            try:
+                await validate_legacy_unit(self.hass, user_input[CONF_IP_ADDRESS])
+            except CannotConnect:
+                errors["base"] = "cannot_connect"
+            except Exception:  # pylint: disable=broad-except
+                _LOGGER.exception("Unexpected exception")
+                errors["base"] = "unknown"
+            else:
+                entry = self.hass.config_entries.async_get_entry(
+                    self.context["entry_id"]
+                )
+                self.hass.config_entries.async_update_entry(
+                    entry,
+                    data={
+                        **entry.data,
+                        CONF_MODEL: MODEL_LEGACY_P3,
+                        CONF_IP_ADDRESS: user_input[CONF_IP_ADDRESS],
+                    },
+                )
+                return self.async_abort(reason="reauth_successful")
+
+        return self.async_show_form(
+            step_id="reauth_legacy",
+            data_schema=STEP_LEGACY_UNIT_DATA_SCHEMA,
+            errors=errors,
+        )
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
-        """Handle the initial step."""
+        """Handle the initial step - model selection."""
+        if user_input is not None:
+            self.model = user_input[CONF_MODEL]
+            if self.model == MODEL_LEGACY_P3:
+                return await self.async_step_legacy_unit()
+            return await self.async_step_api_key()
+
+        return self.async_show_form(step_id="user", data_schema=STEP_MODEL_DATA_SCHEMA)
+
+    async def async_step_legacy_unit(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Handle legacy P3 unit configuration."""
+        errors: dict[str, str] = {}
+        if user_input is not None:
+            try:
+                await validate_legacy_unit(self.hass, user_input[CONF_IP_ADDRESS])
+            except CannotConnect:
+                errors["base"] = "cannot_connect"
+            except Exception:  # pylint: disable=broad-except
+                _LOGGER.exception("Unexpected exception")
+                errors["base"] = "unknown"
+            else:
+                return self.async_create_entry(
+                    title="Powervault P3",
+                    data={
+                        CONF_MODEL: MODEL_LEGACY_P3,
+                        CONF_IP_ADDRESS: user_input[CONF_IP_ADDRESS],
+                    },
+                )
+
+        return self.async_show_form(
+            step_id="legacy_unit",
+            data_schema=STEP_LEGACY_UNIT_DATA_SCHEMA,
+            errors=errors,
+        )
+
+    async def async_step_api_key(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Handle API key entry for newer Powervault units."""
         errors: dict[str, str] = {}
         if user_input is not None:
             try:
@@ -121,16 +235,34 @@ class PowervaultConfigFlow(ConfigFlow, domain=DOMAIN):  # type: ignore[call-arg]
                     step_id="pick_unit", data_schema=vol.Schema(data_schema)
                 )
 
-                # return self.async_create_entry(title=info["title"], data=user_input)
-
         return self.async_show_form(
-            step_id="user", data_schema=STEP_USER_DATA_SCHEMA, errors=errors
+            step_id="api_key", data_schema=STEP_USER_DATA_SCHEMA, errors=errors
         )
 
+    async def async_step_pick_unit(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Handle the initial step."""
+        if user_input is not None:
+            # Save the picked unit id
+            self.unit_id = user_input["unit_id"]
+            self.unit_name = user_input["unit_name"]
 
-class CannotConnect(HomeAssistantError):
+            # Now we can create the entity
+
+            return self.async_create_entry(
+                title=f"Powervault - {self.unit_name}",
+                data={
+                    CONF_MODEL: MODEL_NEWER,
+                    "api_key": self.api_key,
+                    "unit_id": self.unit_id,
+                },
+            )
+
+
+class CannotConnect(HomeAssistantError):  # pylint: disable=too-few-public-methods
     """Error to indicate we cannot connect."""
 
 
-class InvalidAuth(HomeAssistantError):
+class InvalidAuth(HomeAssistantError):  # pylint: disable=too-few-public-methods
     """Error to indicate there is invalid auth."""

--- a/custom_components/powervault/config_flow.py
+++ b/custom_components/powervault/config_flow.py
@@ -6,7 +6,7 @@ import logging
 from typing import Any
 
 import voluptuous as vol
-from homeassistant.config_entries import ConfigFlow
+from homeassistant.config_entries import ConfigEntry, ConfigFlow, OptionsFlow
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.exceptions import HomeAssistantError
@@ -14,7 +14,17 @@ from homeassistant.helpers.selector import selector
 from powervaultpy import PowerVault
 from powervaultpy.powervault import RequestError, ServerError
 
-from .const import CONF_IP_ADDRESS, CONF_MODEL, DOMAIN, MODEL_LEGACY_P3, MODEL_NEWER
+from .const import (
+    CONF_IP_ADDRESS,
+    CONF_MODEL,
+    CONF_POLL_INTERVAL,
+    DEFAULT_POLL_INTERVAL,
+    DOMAIN,
+    MAX_POLL_INTERVAL,
+    MIN_POLL_INTERVAL,
+    MODEL_LEGACY_P3,
+    MODEL_NEWER,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -82,9 +92,9 @@ async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str,
 
 async def validate_legacy_unit(hass: HomeAssistant, ip_address: str) -> None:
     """Validate connection to a legacy P3 Powervault unit via the health endpoint."""
-    client = PowerVault("")
+    client = PowerVault(local_ip=ip_address)
     try:
-        response = await hass.async_add_executor_job(client.get_health, ip_address)
+        response = await hass.async_add_executor_job(client.get_health)
     except (RequestError, ServerError) as exc:
         raise CannotConnect from exc
 
@@ -92,10 +102,55 @@ async def validate_legacy_unit(hass: HomeAssistant, ip_address: str) -> None:
         raise CannotConnect
 
 
+class PowervaultOptionsFlow(OptionsFlow):  # pylint: disable=too-few-public-methods
+    """Handle options for Powervault (legacy P3 only)."""
+
+    def __init__(self, config_entry: ConfigEntry) -> None:
+        """Initialise the options flow."""
+        self._config_entry = config_entry
+
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Show the poll-interval option."""
+        if user_input is not None:
+            return self.async_create_entry(title="", data=user_input)
+
+        current = self._config_entry.options.get(
+            CONF_POLL_INTERVAL, DEFAULT_POLL_INTERVAL
+        )
+        schema = vol.Schema(
+            {
+                vol.Required(CONF_POLL_INTERVAL, default=current): selector(
+                    {
+                        "number": {
+                            "min": MIN_POLL_INTERVAL,
+                            "max": MAX_POLL_INTERVAL,
+                            "step": 1,
+                            "unit_of_measurement": "s",
+                            "mode": "slider",
+                        }
+                    }
+                ),
+            }
+        )
+        return self.async_show_form(step_id="init", data_schema=schema)
+
+
 class PowervaultConfigFlow(ConfigFlow, domain=DOMAIN):  # type: ignore[call-arg]
     """Handle a config flow for Powervault."""
 
     VERSION = 2
+
+    @staticmethod
+    def async_get_options_flow(
+        config_entry: ConfigEntry,
+    ) -> PowervaultOptionsFlow | None:
+        """Return options flow only for legacy P3 entries."""
+        if config_entry.data.get(CONF_MODEL) == MODEL_LEGACY_P3:
+            return PowervaultOptionsFlow(config_entry)
+        return None
+
     unit_id: str
     unit_name: str
     account_info: dict[str, Any]

--- a/custom_components/powervault/const.py
+++ b/custom_components/powervault/const.py
@@ -12,3 +12,10 @@ POWERVAULT_API_CHANGED: Final = "api_changed"
 POWERVAULT_HTTP_SESSION: Final = "http_session"
 
 UPDATE_INTERVAL = 30
+
+CONF_MODEL: Final = "model"
+CONF_IP_ADDRESS: Final = "ip_address"
+
+MODEL_LEGACY_P3: Final = "legacy_p3"
+MODEL_NEWER: Final = "newer"
+MODEL_UNKNOWN: Final = "unknown"

--- a/custom_components/powervault/const.py
+++ b/custom_components/powervault/const.py
@@ -13,6 +13,11 @@ POWERVAULT_HTTP_SESSION: Final = "http_session"
 
 UPDATE_INTERVAL = 30
 
+CONF_POLL_INTERVAL: Final = "poll_interval"
+DEFAULT_POLL_INTERVAL: Final = 30
+MIN_POLL_INTERVAL: Final = 10
+MAX_POLL_INTERVAL: Final = 60
+
 CONF_MODEL: Final = "model"
 CONF_IP_ADDRESS: Final = "ip_address"
 

--- a/custom_components/powervault/manifest.json
+++ b/custom_components/powervault/manifest.json
@@ -8,8 +8,8 @@
   "homekit": {},
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/adammcdonagh/home-assistant-powervault/issues",
-  "requirements": ["powervaultpy==1.1.0"],
+  "requirements": ["powervaultpy==1.1.3"],
   "ssdp": [],
-  "version": "1.2.7",
+  "version": "2.0.0",
   "zeroconf": []
 }

--- a/custom_components/powervault/select.py
+++ b/custom_components/powervault/select.py
@@ -8,7 +8,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from powervaultpy import VALID_STATUSES
 
-from .const import DOMAIN
+from .const import CONF_IP_ADDRESS, DOMAIN
 from .entity import PowervaultEntity
 from .models import PowervaultRuntimeData
 
@@ -47,7 +47,7 @@ class PowervaultSelectEntity(
         """Return whether the entity is available."""
         return super().available and self.data.battery_state is not None
 
-    @callback  # type: ignore[untyped-decorator]
+    @callback  # type: ignore[misc]
     def _async_update_attrs(self) -> None:
         """Update entity attributes."""
         if self.data.battery_state is not None:
@@ -55,7 +55,7 @@ class PowervaultSelectEntity(
         else:
             self._attr_current_option = None
 
-    @callback  # type: ignore[untyped-decorator]
+    @callback  # type: ignore[misc]
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
         self._async_update_attrs()
@@ -63,11 +63,18 @@ class PowervaultSelectEntity(
 
     async def async_select_option(self, option: str) -> None:
         """Change the current preset."""
-        await self.coordinator.hass.async_add_executor_job(
-            self.powervault.set_battery_state,
-            self.coordinator.config_entry.data["unit_id"],
-            option,
-        )
+        if local_ip := self.coordinator.config_entry.data.get(CONF_IP_ADDRESS):
+            await self.coordinator.hass.async_add_executor_job(
+                self.powervault.set_battery_state,
+                option,
+                local_ip,
+            )
+        else:
+            await self.coordinator.hass.async_add_executor_job(
+                self.powervault.set_battery_state,
+                self.coordinator.config_entry.data["unit_id"],
+                option,
+            )
 
         self._attr_current_option = option
         self.async_write_ha_state()

--- a/custom_components/powervault/select.py
+++ b/custom_components/powervault/select.py
@@ -63,11 +63,12 @@ class PowervaultSelectEntity(
 
     async def async_select_option(self, option: str) -> None:
         """Change the current preset."""
-        if local_ip := self.coordinator.config_entry.data.get(CONF_IP_ADDRESS):
+        if self.coordinator.config_entry.data.get(CONF_IP_ADDRESS):
+            # unit_id is ignored by the library when local_ip is set on the client
             await self.coordinator.hass.async_add_executor_job(
                 self.powervault.set_battery_state,
+                None,
                 option,
-                local_ip,
             )
         else:
             await self.coordinator.hass.async_add_executor_job(

--- a/custom_components/powervault/strings.json
+++ b/custom_components/powervault/strings.json
@@ -1,7 +1,36 @@
 {
   "config": {
     "step": {
+      "reauth_model": {
+        "title": "Confirm your Powervault model",
+        "description": "We need to know which model of Powervault you have. P3 units now use a local connection instead of the cloud API.",
+        "data": {
+          "model": "Powervault model"
+        }
+      },
+      "reauth_legacy": {
+        "title": "Enter your P3 Powervault IP address",
+        "description": "Enter the local IP address of your Powervault P3 unit on your network.",
+        "data": {
+          "ip_address": "IP Address"
+        }
+      },
       "user": {
+        "title": "Select your Powervault model",
+        "description": "Choose the model of Powervault you have.",
+        "data": {
+          "model": "Powervault model"
+        }
+      },
+      "legacy_unit": {
+        "title": "Connect to your Legacy P3 Powervault",
+        "description": "Enter the local IP address of your Powervault P3 unit.",
+        "data": {
+          "ip_address": "IP Address"
+        }
+      },
+      "api_key": {
+        "title": "Enter your Powervault API key",
         "description": "Enter the API key provided by Powervault. This is only given out after you've paid the £60 fee.",
         "data": {
           "api_key": "[%key:common::config_flow::data::api_key%]"
@@ -21,6 +50,7 @@
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "abort": {
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
     }
   }

--- a/custom_components/powervault/strings.json
+++ b/custom_components/powervault/strings.json
@@ -53,5 +53,15 @@
       "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
     }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Powervault P3 options",
+        "data": {
+          "poll_interval": "Polling interval (seconds)"
+        }
+      }
+    }
   }
 }

--- a/custom_components/powervault/translations/en.json
+++ b/custom_components/powervault/translations/en.json
@@ -53,5 +53,15 @@
         "description": "Give the unit a friendly name, and select the one you want from the list below. If you only own one Powervault then just select that"
       }
     }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Powervault P3 options",
+        "data": {
+          "poll_interval": "Polling interval (seconds)"
+        }
+      }
+    }
   }
 }

--- a/custom_components/powervault/translations/en.json
+++ b/custom_components/powervault/translations/en.json
@@ -1,6 +1,7 @@
 {
   "config": {
     "abort": {
+      "reauth_successful": "Re-authentication was successful",
       "already_configured": "Device is already configured"
     },
     "error": {
@@ -9,18 +10,47 @@
       "unknown": "Unexpected error"
     },
     "step": {
+      "reauth_model": {
+        "title": "Confirm your Powervault model",
+        "description": "We need to know which model of Powervault you have. P3 units now use a local connection instead of the cloud API.",
+        "data": {
+          "model": "Powervault model"
+        }
+      },
+      "reauth_legacy": {
+        "title": "Enter your P3 Powervault IP address",
+        "description": "Enter the local IP address of your Powervault P3 unit on your network.",
+        "data": {
+          "ip_address": "IP Address"
+        }
+      },
+      "user": {
+        "title": "Select your Powervault model",
+        "description": "Choose the model of Powervault you have.",
+        "data": {
+          "model": "Powervault model"
+        }
+      },
+      "legacy_unit": {
+        "title": "Connect to your Legacy P3 Powervault",
+        "description": "Enter the local IP address of your Powervault P3 unit.",
+        "data": {
+          "ip_address": "IP Address"
+        }
+      },
+      "api_key": {
+        "title": "Enter your Powervault API key",
+        "description": "Enter the API key provided by Powervault. This is only given out after you've paid the \u00a360 fee.",
+        "data": {
+          "api_key": "API Key"
+        }
+      },
       "pick_unit": {
         "data": {
           "unit_id": "Select your unit from the list below:",
           "unit_name": "Give your unit a name"
         },
         "description": "Give the unit a friendly name, and select the one you want from the list below. If you only own one Powervault then just select that"
-      },
-      "user": {
-        "data": {
-          "api_key": "API Key"
-        },
-        "description": "Enter the API key provided by Powervault. This is only given out after you've paid the \u00a360 fee."
       }
     }
   }


### PR DESCRIPTION
# Summary

Powervault have deprecated the cloud API for P3 units. This release adds full local network support for P3 owners, so the integration continues to work without a cloud dependency.

Newer units (P4/P5) using the paid cloud API are completely unaffected.

# What's new

## Local API support for Legacy P3 units
P3 units can now be connected directly over your local network. During setup, choose "Legacy P3" and enter the unit's local IP address — the integration will validate the connection before saving.

## Automatic migration for existing users
Existing config entries are automatically migrated to the new schema (v2). After upgrading, Home Assistant will mark the integration as requiring reconfiguration and walk you through the steps:

P3 owners — confirm your model and enter your unit's local IP address
P4/P5 owners — confirm your model; your existing API key remains valid and no further changes are needed
Configurable polling interval (P3 only)
Because P3 units are now polled locally, you can tune the polling interval to suit your needs. The default is 30 seconds, adjustable between 10 and 60 seconds via the Configure button in Settings > Devices & Services. Changes take effect immediately without a restart.

Reducing the interval significantly increases the number of state changes recorded per day. See the README for guidance on excluding Powervault entities from the recorder if you want a low interval without inflating your database.

### Today's energy totals
The P3 local path fetches intraday chart data to compute today's cumulative energy totals (kWh) across all channels — grid import/export, solar generation, battery charge/discharge, and home consumption. A last-known-value carry-forward handles any gaps in the data stream.

## Upgrade notes

After upgrading, Home Assistant will prompt all users to reconfigure this integration. This is expected — please follow the on-screen steps. The process takes less than a minute.

## Testing

Tested end-to-end on a live P3 unit over local network
Cloud path (P4/P5) behaviour is unchanged
Migration from v1 config entries verified