### PR TITLE
Additional telemetry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+# v2.1.0
+
+### Changed
+
+- Bumped `powervaultpy` to `v1.1.5`
+- **Legacy local units now identify themselves more accurately.** The integration now detects whether a local Powervault is a `P3` or `P3X`, this is used to determine which battery sensors to read. The Home Assistant device model for local units now reflects the detected platform, for example `Powervault P3X`.
+
+### Added
+
+- **Expanded local telemetry for P3 and P3X units.** Local API users now get additional diagnostic sensors for inverter, current, temperature, battery health, and VOC sensor (not available for P3X units) data where the Powervault reports it.
+- **New "Battery Diagnostics" child device.** Additional battery-health sensors are now grouped under a separate child device to avoid cluttering the main Powervault device.
+- **P3X battery summary sensors.** P3X users now get summary battery diagnostics such as minimum and maximum cell voltage, minimum/maximum/average cell temperature, and minimum/maximum/average BMS and MOSFET temperatures.
+- **P3 battery summary sensors.** Legacy P3 users now get derived summary sensors for pack temperature, backplane temperature, and string cell voltage and temperature.
+- **Battery module total voltage sensors.** Local units now expose derived total-voltage sensors for each battery module or string on the Battery Diagnostics device. Two additional aggregate sensors are also provided by default: average battery module total voltage and maximum battery module total voltage.
+- **Optional detailed battery telemetry.** A new **Configure** option for local units lets advanced users enable detailed per-cell battery telemetry when needed. This create a unique device per battery module with it's own per-cell telemetry.
+
 # v2.0.1
 
 **NOTE** If Powervault local data is lost in the 1st 24 hrs of updating, the data may be incorrect. Data is collected in case of Powervault history failure from midnight. This will correct itself at midnight.

--- a/custom_components/powervault/__init__.py
+++ b/custom_components/powervault/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import re
 from dataclasses import replace
 from datetime import date
 from datetime import datetime as dt
@@ -23,19 +24,34 @@ from powervaultpy.powervault import ServerError
 from .const import (
     CONF_IP_ADDRESS,
     CONF_MODEL,
+    CONF_PLATFORM,
     CONF_POLL_INTERVAL,
     CONF_USE_API_HISTORY,
     DEFAULT_POLL_INTERVAL,
     DOMAIN,
+    LEGACY_PLATFORM_P3,
+    LEGACY_PLATFORM_P3X,
+    LEGACY_PLATFORMS,
     MODEL_LEGACY_P3,
     MODEL_UNKNOWN,
     POWERVAULT_COORDINATOR,
     POWERVAULT_MANAGER,
     UPDATE_INTERVAL,
 )
-from .models import PowervaultBaseInfo, PowervaultData, PowervaultRuntimeData
+from .models import (
+    PowervaultBaseInfo,
+    PowervaultData,
+    PowervaultRuntimeData,
+    TelemetryValue,
+)
 
 _LOGGER = logging.getLogger(__name__)
+P3_STRING_CELL_RE = re.compile(r"^(string\d+)cell\d+(Voltage|Temperature)$")
+P3_PACK_TEMPERATURE_RE = re.compile(r"^pack\d+Temperature$")
+P3_BACKPLANE_TEMPERATURE_RE = re.compile(r"^backplane\d+Temperature$")
+P3_STRING_VOLTAGE_RE = re.compile(r"^string\d+cell\d+Voltage$")
+P3_STRING_TEMPERATURE_RE = re.compile(r"^string\d+cell\d+Temperature$")
+P3X_MODULE_CELL_RE = re.compile(r"^(pylontechModule\d+)cell\d+(Voltage|Temperature)$")
 PLATFORMS: list[Platform] = [
     Platform.SENSOR,
     Platform.SELECT,
@@ -59,13 +75,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         local_ip = entry.data[CONF_IP_ADDRESS]
         client = PowerVault(local_ip=local_ip)
         unit_id = None
+        local_platform = await _async_ensure_legacy_platform(hass, entry, client)
         base_info = await hass.async_add_executor_job(
-            _fetch_base_info_legacy, client, local_ip
+            _fetch_base_info_legacy, client, local_platform
         )
     else:
         api_key = entry.data["api_key"]
         unit_id = entry.data["unit_id"]
         local_ip = None
+        local_platform = None
         client = PowerVault(api_key)
         base_info = await hass.async_add_executor_job(_fetch_base_info, client, unit_id)
 
@@ -79,7 +97,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     )
 
     manager = PowervaultDataManager(
-        hass, client, unit_id, runtime_data, local_ip=local_ip, config_entry=entry
+        hass=hass,
+        client=client,
+        unit_id=unit_id,
+        runtime_data=runtime_data,
+        local_ip=local_ip,
+        local_platform=local_platform,
+        config_entry=entry,
     )
     runtime_data[POWERVAULT_MANAGER] = manager
 
@@ -136,11 +160,38 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
         hass.config_entries.async_update_entry(
             config_entry,
             data={**config_entry.data, CONF_MODEL: MODEL_UNKNOWN},
-            version=2,
+            version=3,
         )
         _LOGGER.info(
-            "Migrated Powervault config entry to version 2; user must confirm model"
+            "Migrated Powervault config entry to version 3; user must confirm model"
         )
+        return True
+
+    if config_entry.version == 2:
+        updated_data = dict(config_entry.data)
+
+        if (
+            updated_data.get(CONF_MODEL) == MODEL_LEGACY_P3
+            and updated_data.get(CONF_PLATFORM) not in LEGACY_PLATFORMS
+            and (local_ip := updated_data.get(CONF_IP_ADDRESS))
+        ):
+            client = PowerVault(local_ip=local_ip)
+            try:
+                updated_data[CONF_PLATFORM] = await hass.async_add_executor_job(
+                    _fetch_legacy_platform, client
+                )
+            except Exception as err:  # pylint: disable=broad-except
+                _LOGGER.warning(
+                    "Unable to determine stored Powervault local platform during migration: %s",
+                    err,
+                )
+
+        hass.config_entries.async_update_entry(
+            config_entry,
+            data=updated_data,
+            version=3,
+        )
+        _LOGGER.info("Migrated Powervault config entry to version 3")
         return True
 
     _LOGGER.error(
@@ -163,16 +214,61 @@ def _fetch_base_info(client: PowerVault, unit_id: str) -> PowervaultBaseInfo:
     return _call_base_info(client, unit_id)
 
 
-def _fetch_base_info_legacy(client: PowerVault, _local_ip: str) -> PowervaultBaseInfo:
+def _fetch_base_info_legacy(
+    client: PowerVault, local_platform: str
+) -> PowervaultBaseInfo:
     uid = client.get_unit_id()
-    return PowervaultBaseInfo(id=uid, model="Powervault P3", eprom_id="")
+    return PowervaultBaseInfo(
+        id=uid,
+        model=f"Powervault {local_platform.upper()}",
+        eprom_id="",
+    )
+
+
+def _fetch_legacy_platform(client: PowerVault) -> str:
+    """Return a normalized stored platform value for a legacy local unit."""
+    return _normalize_legacy_platform(client.get_platform())
+
+
+def _normalize_legacy_platform(platform: str | None) -> str:
+    """Validate and normalize a local platform identifier."""
+    if platform is None:
+        raise ValueError("Powervault local platform is missing")
+
+    if (normalized := platform.strip().lower()) not in LEGACY_PLATFORMS:
+        raise ValueError(f"Unsupported Powervault local platform: {platform}")
+
+    return normalized
+
+
+async def _async_ensure_legacy_platform(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    client: PowerVault,
+) -> str:
+    """Return the stored legacy platform, persisting it once if missing."""
+    stored_platform = entry.data.get(CONF_PLATFORM)
+    if isinstance(stored_platform, str) and stored_platform in LEGACY_PLATFORMS:
+        return stored_platform
+
+    detected_platform = cast(
+        str,
+        await hass.async_add_executor_job(_fetch_legacy_platform, client),
+    )
+    hass.config_entries.async_update_entry(
+        entry,
+        data={**entry.data, CONF_PLATFORM: detected_platform},
+    )
+    return detected_platform
 
 
 def _call_base_info(client: PowerVault, unit_id: str) -> PowervaultBaseInfo:
     """Return PowervaultBaseInfo for the device."""
     unit_data = client.get_unit(unit_id)
     return PowervaultBaseInfo(
-        id=unit_data["id"], model=unit_data["model"], eprom_id=unit_data["epromId"]
+        id=cast(str, unit_data["id"]),
+        model=cast(str, unit_data["model"]),
+        eprom_id=cast(str, unit_data["epromId"]),
     )
 
 
@@ -459,12 +555,14 @@ class PowervaultDataManager:  # pylint: disable=too-few-public-methods,too-many-
         unit_id: str | None,
         runtime_data: PowervaultRuntimeData,
         local_ip: str | None = None,
+        local_platform: str | None = None,
         config_entry: ConfigEntry | None = None,
     ) -> None:
         """Init the data manager."""
         self.hass = hass
         self.unit_id = unit_id
         self.local_ip = local_ip
+        self.local_platform = local_platform
         self.runtime_data = runtime_data
         self.client = client
         self.config_entry = config_entry
@@ -533,7 +631,10 @@ class PowervaultDataManager:  # pylint: disable=too-few-public-methods,too-many-
         for _ in range(2):
             try:
                 data = _fetch_powervault_data(
-                    self.client, self.unit_id, local_ip=self.local_ip
+                    self.client,
+                    self.unit_id,
+                    local_ip=self.local_ip,
+                    local_platform=self.local_platform,
                 )
             except ServerError as err:
                 raise UpdateFailed("Unable to fetch data from powervault") from err
@@ -623,18 +724,27 @@ class PowervaultDataManager:  # pylint: disable=too-few-public-methods,too-many-
 
 
 def _fetch_powervault_data(  # pylint: disable=too-many-branches
-    client: PowerVault, unit_id: str | None, local_ip: str | None = None
+    client: PowerVault,
+    unit_id: str | None,
+    local_ip: str | None = None,
+    local_platform: str | None = None,
 ) -> PowervaultData:
     """Process and update powervault data."""
     if local_ip:
-        return _fetch_powervault_data_legacy(client)
+        return _fetch_powervault_data_legacy(client, local_platform)
     return _fetch_powervault_data_cloud(client, unit_id)  # type: ignore[arg-type]
 
 
 def _fetch_powervault_data_legacy(  # pylint: disable=too-many-locals,too-many-statements
     client: PowerVault,
+    local_platform: str | None,
 ) -> PowervaultData:
     """Fetch data from a legacy P3 Powervault unit via the local REST API."""
+    if local_platform not in LEGACY_PLATFORMS:
+        raise ServerError("Legacy Powervault platform is not configured")
+
+    legacy_platform = local_platform
+
     data = client.get_data(None)
 
     _LOGGER.debug(f"Local data: {data}")
@@ -658,6 +768,13 @@ def _fetch_powervault_data_legacy(  # pylint: disable=too-many-locals,too-many-s
         raise ServerError(
             "Failed to get data from Powervault local API. Missing expected measurements."
         )
+
+    common_telemetry, battery_diagnostics, detailed_battery = (
+        _classify_legacy_telemetry(
+            telemetry,
+            legacy_platform,
+        )
+    )
 
     battery_state = "UNKNOWN"
     try:
@@ -727,6 +844,9 @@ def _fetch_powervault_data_legacy(  # pylint: disable=too-many-locals,too-many-s
         instant_solar=instant_solar_gen_w * milli,
         battery_state=battery_state,
         totals={},
+        common_telemetry=common_telemetry,
+        battery_diagnostics=battery_diagnostics,
+        detailed_battery=detailed_battery,
     )
 
 
@@ -825,4 +945,168 @@ def _fetch_powervault_data_cloud(  # pylint: disable=too-many-branches
         ),
         battery_state=battery_state,
         totals=totals,
+        common_telemetry={},
+        battery_diagnostics={},
+        detailed_battery={},
     )
+
+
+def _classify_legacy_telemetry(
+    telemetry: dict[str, object],
+    local_platform: str,
+) -> tuple[
+    dict[str, TelemetryValue],
+    dict[str, TelemetryValue],
+    dict[str, dict[str, TelemetryValue]],
+]:
+    """Split legacy telemetry into common, summary, and detailed groups."""
+    common_telemetry: dict[str, TelemetryValue] = {}
+    battery_diagnostics: dict[str, TelemetryValue] = {}
+    detailed_battery: dict[str, dict[str, TelemetryValue]] = {}
+
+    for key in (
+        "gridCurrent",
+        "batteryCurrent",
+        "inverterVoltage",
+        "inverterFrequency",
+        "maxChargePower",
+        "maxDischargePower",
+        "temperature",
+        "cpuTemperature",
+        "vocTemperature",
+        "vocHumidity",
+        "vocCO2",
+        "vocVOC",
+        "actualState",
+    ):
+        value = telemetry.get(key)
+        if isinstance(value, str | int | float):
+            common_telemetry[key] = value
+
+    soc_average = telemetry.get("socAverage")
+    if isinstance(soc_average, int | float):
+        battery_diagnostics["socAverage"] = soc_average
+
+    if local_platform == LEGACY_PLATFORM_P3:
+        battery_diagnostics.update(_build_p3_battery_diagnostics(telemetry))
+        detailed_battery.update(_build_p3_detailed_battery(telemetry))
+    elif local_platform == LEGACY_PLATFORM_P3X:
+        battery_diagnostics.update(_build_p3x_battery_diagnostics(telemetry))
+        detailed_battery.update(_build_p3x_detailed_battery(telemetry))
+
+    return common_telemetry, battery_diagnostics, detailed_battery
+
+
+def _build_summary_metrics(
+    prefix: str,
+    values: list[float],
+    *,
+    precision: int,
+) -> dict[str, float]:
+    """Return min/max/avg summary metrics for a numeric series."""
+    if not values:
+        return {}
+
+    return {
+        f"{prefix}_min": round(min(values), precision),
+        f"{prefix}_max": round(max(values), precision),
+        f"{prefix}_avg": round(sum(values) / len(values), precision),
+    }
+
+
+def _matching_numeric_values(
+    telemetry: dict[str, object],
+    pattern: re.Pattern[str],
+) -> list[float]:
+    """Return numeric telemetry values that match a measurement pattern."""
+    return [
+        float(value)
+        for key, value in telemetry.items()
+        if pattern.match(key) and isinstance(value, int | float)
+    ]
+
+
+def _build_p3_battery_diagnostics(
+    telemetry: dict[str, object],
+) -> dict[str, TelemetryValue]:
+    """Build summary battery telemetry for legacy P3 hardware."""
+    diagnostics: dict[str, TelemetryValue] = {}
+    diagnostics.update(
+        _build_summary_metrics(
+            "pack_temperature",
+            _matching_numeric_values(telemetry, P3_PACK_TEMPERATURE_RE),
+            precision=1,
+        )
+    )
+    diagnostics.update(
+        _build_summary_metrics(
+            "backplane_temperature",
+            _matching_numeric_values(telemetry, P3_BACKPLANE_TEMPERATURE_RE),
+            precision=1,
+        )
+    )
+    diagnostics.update(
+        _build_summary_metrics(
+            "string_cell_voltage",
+            _matching_numeric_values(telemetry, P3_STRING_VOLTAGE_RE),
+            precision=3,
+        )
+    )
+    diagnostics.update(
+        _build_summary_metrics(
+            "string_cell_temperature",
+            _matching_numeric_values(telemetry, P3_STRING_TEMPERATURE_RE),
+            precision=1,
+        )
+    )
+    return diagnostics
+
+
+def _build_p3_detailed_battery(
+    telemetry: dict[str, object],
+) -> dict[str, dict[str, TelemetryValue]]:
+    """Group detailed per-string telemetry for legacy P3 hardware."""
+    grouped: dict[str, dict[str, TelemetryValue]] = {}
+    for key, value in telemetry.items():
+        if not isinstance(value, int | float):
+            continue
+        if match := P3_STRING_CELL_RE.match(key):
+            grouped.setdefault(match.group(1), {})[key] = value
+    return grouped
+
+
+def _build_p3x_battery_diagnostics(
+    telemetry: dict[str, object],
+) -> dict[str, TelemetryValue]:
+    """Build summary battery telemetry for legacy P3X hardware."""
+    diagnostics: dict[str, TelemetryValue] = {}
+    for key in (
+        "pylontechMinCellVoltage",
+        "pylontechMaxCellVoltage",
+        "pylontechMinCellTemperature",
+        "pylontechMaxCellTemperature",
+        "pylontechAvgCellTemperature",
+        "pylontechMinBMSTemperature",
+        "pylontechMaxBMSTemperature",
+        "pylontechAvgBMSTemperature",
+        "pylontechMinMOSFETTemperature",
+        "pylontechMaxMOSFETTemperature",
+        "pylontechAvgMOSFETTemperature",
+    ):
+        value = telemetry.get(key)
+        if isinstance(value, int | float):
+            diagnostics[key] = value
+    return diagnostics
+
+
+def _build_p3x_detailed_battery(
+    telemetry: dict[str, object],
+) -> dict[str, dict[str, TelemetryValue]]:
+    """Group detailed per-module telemetry for legacy P3X hardware."""
+    grouped: dict[str, dict[str, TelemetryValue]] = {}
+    for key, value in telemetry.items():
+        if not isinstance(value, int | float):
+            continue
+        if match := P3X_MODULE_CELL_RE.match(key):
+            grouped.setdefault(match.group(1), {})[key] = value
+    return grouped

--- a/custom_components/powervault/__init__.py
+++ b/custom_components/powervault/__init__.py
@@ -6,8 +6,8 @@ import logging
 from dataclasses import replace
 from datetime import date
 from datetime import datetime as dt
-from datetime import timedelta
-from zoneinfo import ZoneInfo
+from datetime import timedelta, timezone, tzinfo
+from typing import cast
 
 import requests
 from homeassistant.config_entries import ConfigEntry
@@ -16,6 +16,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.storage import Store
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+from homeassistant.util import dt as dt_util
 from powervaultpy import PowerVault
 from powervaultpy.powervault import ServerError
 
@@ -29,12 +30,18 @@ from .const import (
     MODEL_LEGACY_P3,
     MODEL_UNKNOWN,
     POWERVAULT_COORDINATOR,
+    POWERVAULT_MANAGER,
     UPDATE_INTERVAL,
 )
 from .models import PowervaultBaseInfo, PowervaultData, PowervaultRuntimeData
 
 _LOGGER = logging.getLogger(__name__)
-PLATFORMS: list[Platform] = [Platform.SENSOR, Platform.SELECT, Platform.SWITCH]
+PLATFORMS: list[Platform] = [
+    Platform.SENSOR,
+    Platform.SELECT,
+    Platform.SWITCH,
+    Platform.BUTTON,
+]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
@@ -68,11 +75,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         http_session=http_session,
         coordinator=None,
         api_instance=client,
+        manager=None,  # type: ignore[typeddict-item]
     )
 
     manager = PowervaultDataManager(
         hass, client, unit_id, runtime_data, local_ip=local_ip, config_entry=entry
     )
+    runtime_data[POWERVAULT_MANAGER] = manager
 
     if local_ip:
         await manager.async_initialize()
@@ -253,14 +262,106 @@ def _compute_sample_flows(
     }
 
 
-def _try_fetch_chart_totals(client: PowerVault) -> dict[str, float] | None:
+def _get_local_timezone(hass: HomeAssistant) -> tzinfo:
+    """Return the configured Home Assistant timezone, falling back safely."""
+    if tz_name := hass.config.time_zone:
+        if time_zone := dt_util.get_time_zone(tz_name):
+            return cast(tzinfo, time_zone)
+
+    if (default_time_zone := dt_util.DEFAULT_TIME_ZONE) is not None:
+        return cast(tzinfo, default_time_zone)
+
+    return timezone.utc
+
+
+def _parse_chart_timestamp(value: object) -> dt | None:
+    """Parse a chart data timestamp into a timezone-aware UTC datetime."""
+    if isinstance(value, int | float):
+        timestamp_value = value / 1000 if value > 1_000_000_000_000 else value
+        return dt.fromtimestamp(timestamp_value, tz=timezone.utc)
+
+    if isinstance(value, str):
+        try:
+            parsed = dt.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            return None
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return parsed.astimezone(timezone.utc)
+
+    return None
+
+
+def _normalize_chart_samples(chart_data: object) -> list[dict[str, object]]:
+    """Normalize chart data into a flat list of per-sample dicts."""
+    if not isinstance(chart_data, list):
+        return []
+
+    samples: list[dict[str, object]] = []
+
+    for entry in chart_data:
+        if isinstance(entry, dict):
+            samples.append(dict(entry))
+            continue
+
+        if not isinstance(entry, list):
+            continue
+
+        sample: dict[str, object] = {}
+        for item in entry:
+            if not isinstance(item, dict):
+                continue
+
+            if "timestamp" not in sample and item.get("timestamp") is not None:
+                sample["timestamp"] = item["timestamp"]
+            if "created_at" not in sample and item.get("created_at") is not None:
+                sample["created_at"] = item["created_at"]
+
+            measurement = item.get("measurement")
+            value = item.get("value")
+            if measurement is not None and value is not None:
+                sample[str(measurement)] = value
+
+        if sample:
+            samples.append(sample)
+
+    return samples
+
+
+def _filter_current_day_chart_samples(
+    chart_data: object, local_tz: tzinfo, today: date
+) -> tuple[list[dict[str, object]], int]:
+    """Return only samples that belong to the current local date."""
+    current_day_samples: list[dict[str, object]] = []
+    skipped_samples = 0
+
+    for sample in _normalize_chart_samples(chart_data):
+        parsed_timestamp = _parse_chart_timestamp(
+            sample.get("timestamp") or sample.get("created_at")
+        )
+        if parsed_timestamp is None:
+            skipped_samples += 1
+            continue
+
+        if parsed_timestamp.astimezone(local_tz).date() != today:
+            skipped_samples += 1
+            continue
+
+        current_day_samples.append(sample)
+
+    return current_day_samples, skipped_samples
+
+
+def _try_fetch_chart_totals(  # pylint: disable=too-many-locals
+    client: PowerVault, local_tz: tzinfo
+) -> dict[str, float] | None:
     """Fetch today's chart data and derive energy totals.
 
     Returns a dict keyed by the standard total keys (values in Wh) on success,
     or None if the fetch fails or the data appears incomplete.
     """
-    local_tz = ZoneInfo("Europe/London")
     now_local = dt.now(local_tz)
+    today = now_local.date()
     today_midnight = dt(
         now_local.year, now_local.month, now_local.day, 0, 0, 0, tzinfo=local_tz
     )
@@ -276,6 +377,25 @@ def _try_fetch_chart_totals(client: PowerVault) -> dict[str, float] | None:
 
     if not chart_data:
         return None
+
+    valid_chart_data, skipped_samples = _filter_current_day_chart_samples(
+        chart_data, local_tz, today
+    )
+
+    if not valid_chart_data:
+        if skipped_samples:
+            _LOGGER.debug(
+                "Discarding chart totals because no samples matched local date %s",
+                today,
+            )
+        return None
+
+    if skipped_samples:
+        _LOGGER.debug(
+            "Skipped %s chart samples outside local date %s",
+            skipped_samples,
+            today,
+        )
 
     interval_wh = 30 / 3600  # 30-second samples
     acc: dict[str, float] = dict.fromkeys(
@@ -297,15 +417,17 @@ def _try_fetch_chart_totals(client: PowerVault) -> dict[str, float] | None:
     last_battery_w: float = 0.0
     last_solar_w: float = 0.0
 
-    for timestamp_group in chart_data:
-        measurements: dict[str, float] = {
-            item["measurement"]: item["value"]
-            for item in timestamp_group
-            if item.get("measurement") is not None and item.get("value") is not None
-        }
-        last_grid_w = measurements.get("gridPower", last_grid_w)
-        last_battery_w = measurements.get("batteryPower", last_battery_w)
-        last_solar_w = measurements.get("aux1Power", last_solar_w)
+    for sample in valid_chart_data:
+        grid_power = sample.get("gridPower")
+        battery_power = sample.get("batteryPower")
+        solar_power = sample.get("aux1Power")
+
+        if isinstance(grid_power, int | float):
+            last_grid_w = float(grid_power)
+        if isinstance(battery_power, int | float):
+            last_battery_w = float(battery_power)
+        if isinstance(solar_power, int | float):
+            last_solar_w = float(solar_power)
 
         for key, delta in _compute_sample_flows(
             last_grid_w, last_battery_w, last_solar_w, interval_wh
@@ -346,6 +468,7 @@ class PowervaultDataManager:  # pylint: disable=too-few-public-methods,too-many-
         self.runtime_data = runtime_data
         self.client = client
         self.config_entry = config_entry
+        self._local_tz = _get_local_timezone(hass)
         # Incremental energy accumulator for local P3 path.
         self._acc: dict[str, float] = dict.fromkeys(self._TOTAL_KEYS, 0.0)
         self._last_poll_time: dt | None = None
@@ -367,8 +490,7 @@ class PowervaultDataManager:  # pylint: disable=too-few-public-methods,too-many-
         if not (stored_date_str := stored.get("date")):
             return
         stored_date = date.fromisoformat(stored_date_str)
-        local_tz = ZoneInfo("Europe/London")
-        today = dt.now(local_tz).date()
+        today = dt.now(self._local_tz).date()
         if stored_date != today:
             _LOGGER.debug("Persisted accumulator is from a previous day — discarding")
             await self._store.async_remove()
@@ -397,6 +519,14 @@ class PowervaultDataManager:  # pylint: disable=too-few-public-methods,too-many-
                 {"date": self._acc_date.isoformat(), "acc": dict(self._acc)}
             )
 
+    async def async_reset_cached_totals(self) -> None:
+        """Clear cached daily totals and persisted accumulator state."""
+        self._acc = dict.fromkeys(self._TOTAL_KEYS, 0.0)
+        self._last_poll_time = None
+        self._acc_date = dt.now(self._local_tz).date()
+        if self._store:
+            await self._store.async_remove()
+
     def _update_data(self) -> PowervaultData:
         """Fetch data from API endpoint."""
         _LOGGER.debug("Updating data")
@@ -415,7 +545,9 @@ class PowervaultDataManager:  # pylint: disable=too-few-public-methods,too-many-
                     else True
                 )
                 api_totals = (
-                    _try_fetch_chart_totals(self.client) if use_history else None
+                    _try_fetch_chart_totals(self.client, self._local_tz)
+                    if use_history
+                    else None
                 )
                 data = self._accumulate(data, api_totals=api_totals)
 
@@ -437,8 +569,7 @@ class PowervaultDataManager:  # pylint: disable=too-few-public-methods,too-many-
            dropped below the accumulator — indicating a mid-day history reset —
            the accumulator is kept, so the total never goes backwards.
         """
-        local_tz = ZoneInfo("Europe/London")
-        now = dt.now(local_tz)
+        now = dt.now(self._local_tz)
         today = now.date()
 
         # Reset at midnight.

--- a/custom_components/powervault/__init__.py
+++ b/custom_components/powervault/__init__.py
@@ -554,6 +554,7 @@ class PowervaultDataManager:  # pylint: disable=too-few-public-methods,too-many-
         client: PowerVault,
         unit_id: str | None,
         runtime_data: PowervaultRuntimeData,
+        *,
         local_ip: str | None = None,
         local_platform: str | None = None,
         config_entry: ConfigEntry | None = None,
@@ -731,19 +732,21 @@ def _fetch_powervault_data(  # pylint: disable=too-many-branches
 ) -> PowervaultData:
     """Process and update powervault data."""
     if local_ip:
+        if local_platform is None:
+            raise ServerError(
+                "Missing local platform for Powervault legacy telemetry fetch."
+            )
         return _fetch_powervault_data_legacy(client, local_platform)
     return _fetch_powervault_data_cloud(client, unit_id)  # type: ignore[arg-type]
 
 
 def _fetch_powervault_data_legacy(  # pylint: disable=too-many-locals,too-many-statements
     client: PowerVault,
-    local_platform: str | None,
+    local_platform: str,
 ) -> PowervaultData:
     """Fetch data from a legacy P3 Powervault unit via the local REST API."""
     if local_platform not in LEGACY_PLATFORMS:
         raise ServerError("Legacy Powervault platform is not configured")
-
-    legacy_platform = local_platform
 
     data = client.get_data(None)
 
@@ -772,7 +775,7 @@ def _fetch_powervault_data_legacy(  # pylint: disable=too-many-locals,too-many-s
     common_telemetry, battery_diagnostics, detailed_battery = (
         _classify_legacy_telemetry(
             telemetry,
-            legacy_platform,
+            local_platform,
         )
     )
 

--- a/custom_components/powervault/button.py
+++ b/custom_components/powervault/button.py
@@ -1,0 +1,54 @@
+"""Support for Powervault buttons."""
+
+from __future__ import annotations
+
+from homeassistant.components.button import ButtonEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import CONF_IP_ADDRESS, DOMAIN, POWERVAULT_MANAGER
+from .entity import PowervaultEntity
+from .models import PowervaultRuntimeData
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Powervault button entities."""
+    powervault_data: PowervaultRuntimeData = hass.data[DOMAIN][config_entry.entry_id]
+
+    if config_entry.data.get(CONF_IP_ADDRESS):
+        async_add_entities([PowervaultResetTotalsButton(powervault_data)])
+
+
+class PowervaultResetTotalsButton(PowervaultEntity, ButtonEntity):
+    """Button to clear cached local totals and refresh from current history."""
+
+    _attr_name = "Powervault Reset Cached Totals"
+    _attr_icon = "mdi:counter"
+
+    def __init__(self, powervault_data: PowervaultRuntimeData) -> None:
+        """Initialize the button."""
+        super().__init__(powervault_data)
+        self._manager = powervault_data[POWERVAULT_MANAGER]
+
+    @property
+    def unique_id(self) -> str:
+        """Device unique id."""
+        return f"{self.base_unique_id}_reset_cached_totals"
+
+    def press(self) -> None:
+        """Clear cached totals and schedule an immediate refresh."""
+        self.hass.async_create_task(self._async_reset_and_refresh())
+
+    async def async_press(self) -> None:
+        """Clear cached totals and force an immediate refresh."""
+        await self._async_reset_and_refresh()
+
+    async def _async_reset_and_refresh(self) -> None:
+        """Run the cached total reset flow."""
+        await self._manager.async_reset_cached_totals()
+        await self.coordinator.async_request_refresh()

--- a/custom_components/powervault/config_flow.py
+++ b/custom_components/powervault/config_flow.py
@@ -15,11 +15,16 @@ from powervaultpy import PowerVault
 from powervaultpy.powervault import RequestError, ServerError
 
 from .const import (
+    CONF_ENABLE_DETAILED_BATTERY_TELEMETRY,
     CONF_IP_ADDRESS,
     CONF_MODEL,
+    CONF_PLATFORM,
     CONF_POLL_INTERVAL,
+    DEFAULT_ENABLE_DETAILED_BATTERY_TELEMETRY,
     DEFAULT_POLL_INTERVAL,
     DOMAIN,
+    LEGACY_PLATFORM_P3,
+    LEGACY_PLATFORMS,
     MAX_POLL_INTERVAL,
     MIN_POLL_INTERVAL,
     MODEL_LEGACY_P3,
@@ -90,16 +95,30 @@ async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str,
     return {"units": units_, "account_id": account_id}
 
 
-async def validate_legacy_unit(hass: HomeAssistant, ip_address: str) -> None:
-    """Validate connection to a legacy P3 Powervault unit via the health endpoint."""
+def _normalize_legacy_platform(platform: str | None) -> str:
+    """Validate and normalize the reported legacy platform string."""
+    if platform is None:
+        raise CannotConnect
+
+    if (normalized := platform.strip().lower()) not in LEGACY_PLATFORMS:
+        raise CannotConnect
+
+    return normalized
+
+
+async def validate_legacy_unit(hass: HomeAssistant, ip_address: str) -> str:
+    """Validate a legacy local unit and return its stored platform type."""
     client = PowerVault(local_ip=ip_address)
     try:
         response = await hass.async_add_executor_job(client.get_health)
+        platform = await hass.async_add_executor_job(client.get_platform)
     except (RequestError, ServerError) as exc:
         raise CannotConnect from exc
 
     if response != {"status": "ok"}:
         raise CannotConnect
+
+    return _normalize_legacy_platform(platform)
 
 
 class PowervaultOptionsFlow(OptionsFlow):  # pylint: disable=too-few-public-methods
@@ -119,6 +138,10 @@ class PowervaultOptionsFlow(OptionsFlow):  # pylint: disable=too-few-public-meth
         current = self._config_entry.options.get(
             CONF_POLL_INTERVAL, DEFAULT_POLL_INTERVAL
         )
+        current_detailed = self._config_entry.options.get(
+            CONF_ENABLE_DETAILED_BATTERY_TELEMETRY,
+            DEFAULT_ENABLE_DETAILED_BATTERY_TELEMETRY,
+        )
         schema = vol.Schema(
             {
                 vol.Required(CONF_POLL_INTERVAL, default=current): selector(
@@ -132,6 +155,10 @@ class PowervaultOptionsFlow(OptionsFlow):  # pylint: disable=too-few-public-meth
                         }
                     }
                 ),
+                vol.Required(
+                    CONF_ENABLE_DETAILED_BATTERY_TELEMETRY,
+                    default=current_detailed,
+                ): selector({"boolean": {}}),
             }
         )
         return self.async_show_form(step_id="init", data_schema=schema)
@@ -140,7 +167,7 @@ class PowervaultOptionsFlow(OptionsFlow):  # pylint: disable=too-few-public-meth
 class PowervaultConfigFlow(ConfigFlow, domain=DOMAIN):  # type: ignore[call-arg]
     """Handle a config flow for Powervault."""
 
-    VERSION = 2
+    VERSION = 3
 
     @staticmethod
     def async_get_options_flow(
@@ -191,7 +218,9 @@ class PowervaultConfigFlow(ConfigFlow, domain=DOMAIN):  # type: ignore[call-arg]
         errors: dict[str, str] = {}
         if user_input is not None:
             try:
-                await validate_legacy_unit(self.hass, user_input[CONF_IP_ADDRESS])
+                platform = await validate_legacy_unit(
+                    self.hass, user_input[CONF_IP_ADDRESS]
+                )
             except CannotConnect:
                 errors["base"] = "cannot_connect"
             except Exception:  # pylint: disable=broad-except
@@ -207,6 +236,7 @@ class PowervaultConfigFlow(ConfigFlow, domain=DOMAIN):  # type: ignore[call-arg]
                         **entry.data,
                         CONF_MODEL: MODEL_LEGACY_P3,
                         CONF_IP_ADDRESS: user_input[CONF_IP_ADDRESS],
+                        CONF_PLATFORM: platform,
                     },
                 )
                 return self.async_abort(reason="reauth_successful")
@@ -236,7 +266,9 @@ class PowervaultConfigFlow(ConfigFlow, domain=DOMAIN):  # type: ignore[call-arg]
         errors: dict[str, str] = {}
         if user_input is not None:
             try:
-                await validate_legacy_unit(self.hass, user_input[CONF_IP_ADDRESS])
+                platform = await validate_legacy_unit(
+                    self.hass, user_input[CONF_IP_ADDRESS]
+                )
             except CannotConnect:
                 errors["base"] = "cannot_connect"
             except Exception:  # pylint: disable=broad-except
@@ -244,10 +276,15 @@ class PowervaultConfigFlow(ConfigFlow, domain=DOMAIN):  # type: ignore[call-arg]
                 errors["base"] = "unknown"
             else:
                 return self.async_create_entry(
-                    title="Powervault P3",
+                    title=(
+                        "Powervault P3"
+                        if platform == LEGACY_PLATFORM_P3
+                        else "Powervault P3X"
+                    ),
                     data={
                         CONF_MODEL: MODEL_LEGACY_P3,
                         CONF_IP_ADDRESS: user_input[CONF_IP_ADDRESS],
+                        CONF_PLATFORM: platform,
                     },
                 )
 

--- a/custom_components/powervault/config_flow.py
+++ b/custom_components/powervault/config_flow.py
@@ -164,7 +164,9 @@ class PowervaultOptionsFlow(OptionsFlow):  # pylint: disable=too-few-public-meth
         return self.async_show_form(step_id="init", data_schema=schema)
 
 
-class PowervaultConfigFlow(ConfigFlow, domain=DOMAIN):  # type: ignore[call-arg]
+class PowervaultConfigFlow(  # pylint: disable=abstract-method
+    ConfigFlow, domain=DOMAIN
+):  # type: ignore[call-arg]
     """Handle a config flow for Powervault."""
 
     VERSION = 3

--- a/custom_components/powervault/const.py
+++ b/custom_components/powervault/const.py
@@ -15,9 +15,12 @@ POWERVAULT_HTTP_SESSION: Final = "http_session"
 UPDATE_INTERVAL = 30
 
 CONF_POLL_INTERVAL: Final = "poll_interval"
+CONF_PLATFORM: Final = "platform"
+CONF_ENABLE_DETAILED_BATTERY_TELEMETRY: Final = "enable_detailed_battery_telemetry"
 DEFAULT_POLL_INTERVAL: Final = 30
 MIN_POLL_INTERVAL: Final = 10
 MAX_POLL_INTERVAL: Final = 60
+DEFAULT_ENABLE_DETAILED_BATTERY_TELEMETRY: Final = False
 
 CONF_MODEL: Final = "model"
 CONF_IP_ADDRESS: Final = "ip_address"
@@ -26,3 +29,7 @@ CONF_USE_API_HISTORY: Final = "use_api_history"
 MODEL_LEGACY_P3: Final = "legacy_p3"
 MODEL_NEWER: Final = "newer"
 MODEL_UNKNOWN: Final = "unknown"
+
+LEGACY_PLATFORM_P3: Final = "p3"
+LEGACY_PLATFORM_P3X: Final = "p3x"
+LEGACY_PLATFORMS: Final = (LEGACY_PLATFORM_P3, LEGACY_PLATFORM_P3X)

--- a/custom_components/powervault/const.py
+++ b/custom_components/powervault/const.py
@@ -8,6 +8,7 @@ MANUFACTURER = "Powervault"
 POWERVAULT_BASE_INFO: Final = "base_info"
 POWERVAULT_COORDINATOR: Final = "coordinator"
 POWERVAULT_API: Final = "api_instance"
+POWERVAULT_MANAGER: Final = "manager"
 POWERVAULT_API_CHANGED: Final = "api_changed"
 POWERVAULT_HTTP_SESSION: Final = "http_session"
 

--- a/custom_components/powervault/entity.py
+++ b/custom_components/powervault/entity.py
@@ -27,6 +27,7 @@ class PowervaultEntity(CoordinatorEntity[DataUpdateCoordinator[PowervaultData]])
         coordinator = powervault_data[POWERVAULT_COORDINATOR]
         assert coordinator is not None
         super().__init__(coordinator)
+        self._base_info = base_info
         self.powervault = powervault_data[POWERVAULT_API]
         # The serial numbers of the powervaults are unique to every site
         self.base_unique_id = "_".join(base_info.id)
@@ -36,6 +37,17 @@ class PowervaultEntity(CoordinatorEntity[DataUpdateCoordinator[PowervaultData]])
             model=base_info.model,
             name=base_info.id,
             sw_version=base_info.eprom_id,
+        )
+
+    def get_child_device_info(self, device_key: str, name: str) -> DeviceInfo:
+        """Return DeviceInfo for a child device linked to the main Powervault."""
+        return DeviceInfo(
+            identifiers={(DOMAIN, f"{self.base_unique_id}_{device_key}")},
+            manufacturer=MANUFACTURER,
+            model=self._base_info.model,
+            name=f"{self._base_info.id} {name}",
+            sw_version=self._base_info.eprom_id,
+            via_device=(DOMAIN, self.base_unique_id),
         )
 
     @property

--- a/custom_components/powervault/manifest.json
+++ b/custom_components/powervault/manifest.json
@@ -10,6 +10,6 @@
   "issue_tracker": "https://github.com/adammcdonagh/home-assistant-powervault/issues",
   "requirements": ["powervaultpy==1.1.5"],
   "ssdp": [],
-  "version": "v2.0.1",
+  "version": "v2.1.0",
   "zeroconf": []
 }

--- a/custom_components/powervault/manifest.json
+++ b/custom_components/powervault/manifest.json
@@ -8,7 +8,7 @@
   "homekit": {},
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/adammcdonagh/home-assistant-powervault/issues",
-  "requirements": ["powervaultpy==1.1.4"],
+  "requirements": ["powervaultpy==1.1.5"],
   "ssdp": [],
   "version": "v2.0.1",
   "zeroconf": []

--- a/custom_components/powervault/models.py
+++ b/custom_components/powervault/models.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, TypedDict
+from typing import TYPE_CHECKING, TypeAlias, TypedDict
 
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from powervaultpy import PowerVault
@@ -11,6 +11,9 @@ from requests import Session
 
 if TYPE_CHECKING:
     from .__init__ import PowervaultDataManager
+
+
+TelemetryValue: TypeAlias = str | int | float
 
 
 @dataclass
@@ -43,6 +46,9 @@ class PowervaultData:  # pylint: disable=too-many-instance-attributes
     instant_solar: float
     battery_state: str | None
     totals: dict
+    common_telemetry: dict[str, TelemetryValue]
+    battery_diagnostics: dict[str, TelemetryValue]
+    detailed_battery: dict[str, dict[str, TelemetryValue]]
 
 
 class PowervaultRuntimeData(TypedDict):

--- a/custom_components/powervault/models.py
+++ b/custom_components/powervault/models.py
@@ -3,11 +3,14 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TypedDict
+from typing import TYPE_CHECKING, TypedDict
 
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from powervaultpy import PowerVault
 from requests import Session
+
+if TYPE_CHECKING:
+    from .__init__ import PowervaultDataManager
 
 
 @dataclass
@@ -47,6 +50,7 @@ class PowervaultRuntimeData(TypedDict):
 
     coordinator: DataUpdateCoordinator[PowervaultData] | None
     api_instance: PowerVault
+    manager: PowervaultDataManager
     base_info: PowervaultBaseInfo
     api_changed: bool
     http_session: Session

--- a/custom_components/powervault/select.py
+++ b/custom_components/powervault/select.py
@@ -47,7 +47,7 @@ class PowervaultSelectEntity(
         """Return whether the entity is available."""
         return super().available and self.data.battery_state is not None
 
-    @callback  # type: ignore[misc]
+    @callback  # type: ignore[misc, untyped-decorator]
     def _async_update_attrs(self) -> None:
         """Update entity attributes."""
         if self.data.battery_state is not None:
@@ -55,7 +55,7 @@ class PowervaultSelectEntity(
         else:
             self._attr_current_option = None
 
-    @callback  # type: ignore[misc]
+    @callback  # type: ignore[misc, untyped-decorator]
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
         self._async_update_attrs()

--- a/custom_components/powervault/sensor.py
+++ b/custom_components/powervault/sensor.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass
+from typing import cast
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -10,14 +12,28 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import PERCENTAGE, UnitOfEnergy, UnitOfPower
+from homeassistant.const import (
+    CONCENTRATION_PARTS_PER_MILLION,
+    PERCENTAGE,
+    UnitOfElectricCurrent,
+    UnitOfElectricPotential,
+    UnitOfEnergy,
+    UnitOfPower,
+    UnitOfTemperature,
+)
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from powervaultpy import PowerVault
 
-from .const import DOMAIN, POWERVAULT_COORDINATOR
+from .const import (
+    CONF_ENABLE_DETAILED_BATTERY_TELEMETRY,
+    CONF_PLATFORM,
+    DOMAIN,
+    LEGACY_PLATFORM_P3,
+    LEGACY_PLATFORM_P3X,
+)
 from .entity import PowervaultEntity
-from .models import PowervaultRuntimeData
+from .models import PowervaultRuntimeData, TelemetryValue
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -84,15 +100,460 @@ power_sensor_names = [
 ]
 
 
+@dataclass(frozen=True)
+# pylint: disable=too-many-instance-attributes
+class PowervaultExtraSensorDescription:
+    """Description of an additive telemetry sensor."""
+
+    key: str
+    name: str
+    source: str
+    unique_id_suffix: str
+    child_device_key: str
+    child_device_name: str
+    native_unit_of_measurement: str | None = None
+    device_class: SensorDeviceClass | None = None
+    state_class: SensorStateClass | None = SensorStateClass.MEASUREMENT
+    entity_category: EntityCategory | None = None
+    precision: int | None = None
+    absolute_value: bool = False
+
+
+COMMON_TELEMETRY_SENSORS: tuple[PowervaultExtraSensorDescription, ...] = (
+    PowervaultExtraSensorDescription(
+        key="gridCurrent",
+        name="Powervault Grid Current",
+        source="common_telemetry",
+        unique_id_suffix="telemetry_gridCurrent",
+        child_device_key="telemetry",
+        child_device_name="Telemetry",
+        native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
+        device_class=SensorDeviceClass.CURRENT,
+        precision=2,
+    ),
+    PowervaultExtraSensorDescription(
+        key="batteryCurrent",
+        name="Powervault Battery Current",
+        source="common_telemetry",
+        unique_id_suffix="telemetry_batteryCurrent",
+        child_device_key="telemetry",
+        child_device_name="Telemetry",
+        native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
+        device_class=SensorDeviceClass.CURRENT,
+        precision=2,
+    ),
+    PowervaultExtraSensorDescription(
+        key="inverterVoltage",
+        name="Powervault Inverter Voltage",
+        source="common_telemetry",
+        unique_id_suffix="telemetry_inverterVoltage",
+        child_device_key="telemetry",
+        child_device_name="Telemetry",
+        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
+        device_class=SensorDeviceClass.VOLTAGE,
+        precision=1,
+    ),
+    PowervaultExtraSensorDescription(
+        key="inverterFrequency",
+        name="Powervault Inverter Frequency",
+        source="common_telemetry",
+        unique_id_suffix="telemetry_inverterFrequency",
+        child_device_key="telemetry",
+        child_device_name="Telemetry",
+        native_unit_of_measurement="Hz",
+        device_class=SensorDeviceClass.FREQUENCY,
+        precision=2,
+    ),
+    PowervaultExtraSensorDescription(
+        key="maxChargePower",
+        name="Powervault Max Charge Power",
+        source="common_telemetry",
+        unique_id_suffix="telemetry_maxChargePower",
+        child_device_key="telemetry",
+        child_device_name="Telemetry",
+        native_unit_of_measurement=UnitOfPower.WATT,
+        device_class=SensorDeviceClass.POWER,
+        precision=0,
+    ),
+    PowervaultExtraSensorDescription(
+        key="maxDischargePower",
+        name="Powervault Max Discharge Power",
+        source="common_telemetry",
+        unique_id_suffix="telemetry_maxDischargePower",
+        child_device_key="telemetry",
+        child_device_name="Telemetry",
+        native_unit_of_measurement=UnitOfPower.WATT,
+        device_class=SensorDeviceClass.POWER,
+        precision=0,
+        absolute_value=True,
+    ),
+    PowervaultExtraSensorDescription(
+        key="temperature",
+        name="Powervault Internal Temperature",
+        source="common_telemetry",
+        unique_id_suffix="telemetry_temperature",
+        child_device_key="telemetry",
+        child_device_name="Telemetry",
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        device_class=SensorDeviceClass.TEMPERATURE,
+        precision=1,
+    ),
+    PowervaultExtraSensorDescription(
+        key="cpuTemperature",
+        name="Powervault CPU Temperature",
+        source="common_telemetry",
+        unique_id_suffix="telemetry_cpuTemperature",
+        child_device_key="telemetry",
+        child_device_name="Telemetry",
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        device_class=SensorDeviceClass.TEMPERATURE,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        precision=1,
+    ),
+    PowervaultExtraSensorDescription(
+        key="vocTemperature",
+        name="Powervault VOC Temperature",
+        source="common_telemetry",
+        unique_id_suffix="telemetry_vocTemperature",
+        child_device_key="telemetry",
+        child_device_name="Telemetry",
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        device_class=SensorDeviceClass.TEMPERATURE,
+        precision=1,
+    ),
+    PowervaultExtraSensorDescription(
+        key="vocHumidity",
+        name="Powervault VOC Humidity",
+        source="common_telemetry",
+        unique_id_suffix="telemetry_vocHumidity",
+        child_device_key="telemetry",
+        child_device_name="Telemetry",
+        native_unit_of_measurement=PERCENTAGE,
+        device_class=SensorDeviceClass.HUMIDITY,
+        precision=1,
+    ),
+    PowervaultExtraSensorDescription(
+        key="vocCO2",
+        name="Powervault VOC CO2",
+        source="common_telemetry",
+        unique_id_suffix="telemetry_vocCO2",
+        child_device_key="telemetry",
+        child_device_name="Telemetry",
+        native_unit_of_measurement=CONCENTRATION_PARTS_PER_MILLION,
+        device_class=SensorDeviceClass.CO2,
+        precision=0,
+    ),
+    PowervaultExtraSensorDescription(
+        key="vocVOC",
+        name="Powervault VOC Index",
+        source="common_telemetry",
+        unique_id_suffix="telemetry_vocVOC",
+        child_device_key="telemetry",
+        child_device_name="Telemetry",
+        native_unit_of_measurement="index",
+        precision=0,
+    ),
+    PowervaultExtraSensorDescription(
+        key="actualState",
+        name="Powervault Actual State",
+        source="common_telemetry",
+        unique_id_suffix="telemetry_actualState",
+        child_device_key="telemetry",
+        child_device_name="Telemetry",
+        state_class=None,
+    ),
+)
+
+COMMON_BATTERY_DIAGNOSTIC_SENSORS: tuple[PowervaultExtraSensorDescription, ...] = (
+    PowervaultExtraSensorDescription(
+        key="socAverage",
+        name="Powervault Average State Of Charge",
+        source="battery_diagnostics",
+        unique_id_suffix="battery_diagnostics_socAverage",
+        child_device_key="battery_diagnostics",
+        child_device_name="Battery Diagnostics",
+        native_unit_of_measurement=PERCENTAGE,
+        device_class=SensorDeviceClass.BATTERY,
+        precision=0,
+    ),
+)
+
+BATTERY_GROUP_SUMMARY_SENSORS: tuple[tuple[str, str], ...] = (
+    ("total_voltage", "Total Voltage"),
+)
+
+BATTERY_GROUP_AGGREGATE_SENSORS: tuple[tuple[str, str], ...] = (
+    ("average_total_voltage", "Average Battery Module Total Voltage"),
+    ("maximum_total_voltage", "Maximum Battery Module Total Voltage"),
+)
+
+P3_BATTERY_DIAGNOSTIC_SENSORS: tuple[PowervaultExtraSensorDescription, ...] = (
+    PowervaultExtraSensorDescription(
+        key="pack_temperature_min",
+        name="Powervault Pack Temperature Min",
+        source="battery_diagnostics",
+        unique_id_suffix="battery_diagnostics_pack_temperature_min",
+        child_device_key="battery_diagnostics",
+        child_device_name="Battery Diagnostics",
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        device_class=SensorDeviceClass.TEMPERATURE,
+        precision=1,
+    ),
+    PowervaultExtraSensorDescription(
+        key="pack_temperature_max",
+        name="Powervault Pack Temperature Max",
+        source="battery_diagnostics",
+        unique_id_suffix="battery_diagnostics_pack_temperature_max",
+        child_device_key="battery_diagnostics",
+        child_device_name="Battery Diagnostics",
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        device_class=SensorDeviceClass.TEMPERATURE,
+        precision=1,
+    ),
+    PowervaultExtraSensorDescription(
+        key="pack_temperature_avg",
+        name="Powervault Pack Temperature Average",
+        source="battery_diagnostics",
+        unique_id_suffix="battery_diagnostics_pack_temperature_avg",
+        child_device_key="battery_diagnostics",
+        child_device_name="Battery Diagnostics",
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        device_class=SensorDeviceClass.TEMPERATURE,
+        precision=1,
+    ),
+    PowervaultExtraSensorDescription(
+        key="backplane_temperature_min",
+        name="Powervault Backplane Temperature Min",
+        source="battery_diagnostics",
+        unique_id_suffix="battery_diagnostics_backplane_temperature_min",
+        child_device_key="battery_diagnostics",
+        child_device_name="Battery Diagnostics",
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        device_class=SensorDeviceClass.TEMPERATURE,
+        precision=1,
+    ),
+    PowervaultExtraSensorDescription(
+        key="backplane_temperature_max",
+        name="Powervault Backplane Temperature Max",
+        source="battery_diagnostics",
+        unique_id_suffix="battery_diagnostics_backplane_temperature_max",
+        child_device_key="battery_diagnostics",
+        child_device_name="Battery Diagnostics",
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        device_class=SensorDeviceClass.TEMPERATURE,
+        precision=1,
+    ),
+    PowervaultExtraSensorDescription(
+        key="backplane_temperature_avg",
+        name="Powervault Backplane Temperature Average",
+        source="battery_diagnostics",
+        unique_id_suffix="battery_diagnostics_backplane_temperature_avg",
+        child_device_key="battery_diagnostics",
+        child_device_name="Battery Diagnostics",
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        device_class=SensorDeviceClass.TEMPERATURE,
+        precision=1,
+    ),
+    PowervaultExtraSensorDescription(
+        key="string_cell_voltage_min",
+        name="Powervault String Cell Voltage Min",
+        source="battery_diagnostics",
+        unique_id_suffix="battery_diagnostics_string_cell_voltage_min",
+        child_device_key="battery_diagnostics",
+        child_device_name="Battery Diagnostics",
+        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
+        device_class=SensorDeviceClass.VOLTAGE,
+        precision=3,
+    ),
+    PowervaultExtraSensorDescription(
+        key="string_cell_voltage_max",
+        name="Powervault String Cell Voltage Max",
+        source="battery_diagnostics",
+        unique_id_suffix="battery_diagnostics_string_cell_voltage_max",
+        child_device_key="battery_diagnostics",
+        child_device_name="Battery Diagnostics",
+        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
+        device_class=SensorDeviceClass.VOLTAGE,
+        precision=3,
+    ),
+    PowervaultExtraSensorDescription(
+        key="string_cell_voltage_avg",
+        name="Powervault String Cell Voltage Average",
+        source="battery_diagnostics",
+        unique_id_suffix="battery_diagnostics_string_cell_voltage_avg",
+        child_device_key="battery_diagnostics",
+        child_device_name="Battery Diagnostics",
+        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
+        device_class=SensorDeviceClass.VOLTAGE,
+        precision=3,
+    ),
+    PowervaultExtraSensorDescription(
+        key="string_cell_temperature_min",
+        name="Powervault String Cell Temperature Min",
+        source="battery_diagnostics",
+        unique_id_suffix="battery_diagnostics_string_cell_temperature_min",
+        child_device_key="battery_diagnostics",
+        child_device_name="Battery Diagnostics",
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        device_class=SensorDeviceClass.TEMPERATURE,
+        precision=1,
+    ),
+    PowervaultExtraSensorDescription(
+        key="string_cell_temperature_max",
+        name="Powervault String Cell Temperature Max",
+        source="battery_diagnostics",
+        unique_id_suffix="battery_diagnostics_string_cell_temperature_max",
+        child_device_key="battery_diagnostics",
+        child_device_name="Battery Diagnostics",
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        device_class=SensorDeviceClass.TEMPERATURE,
+        precision=1,
+    ),
+    PowervaultExtraSensorDescription(
+        key="string_cell_temperature_avg",
+        name="Powervault String Cell Temperature Average",
+        source="battery_diagnostics",
+        unique_id_suffix="battery_diagnostics_string_cell_temperature_avg",
+        child_device_key="battery_diagnostics",
+        child_device_name="Battery Diagnostics",
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        device_class=SensorDeviceClass.TEMPERATURE,
+        precision=1,
+    ),
+)
+
+P3X_BATTERY_DIAGNOSTIC_SENSORS: tuple[PowervaultExtraSensorDescription, ...] = (
+    PowervaultExtraSensorDescription(
+        key="pylontechMinCellVoltage",
+        name="Powervault Pylontech Min Cell Voltage",
+        source="battery_diagnostics",
+        unique_id_suffix="battery_diagnostics_pylontechMinCellVoltage",
+        child_device_key="battery_diagnostics",
+        child_device_name="Battery Diagnostics",
+        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
+        device_class=SensorDeviceClass.VOLTAGE,
+        precision=3,
+    ),
+    PowervaultExtraSensorDescription(
+        key="pylontechMaxCellVoltage",
+        name="Powervault Pylontech Max Cell Voltage",
+        source="battery_diagnostics",
+        unique_id_suffix="battery_diagnostics_pylontechMaxCellVoltage",
+        child_device_key="battery_diagnostics",
+        child_device_name="Battery Diagnostics",
+        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
+        device_class=SensorDeviceClass.VOLTAGE,
+        precision=3,
+    ),
+    PowervaultExtraSensorDescription(
+        key="pylontechMinCellTemperature",
+        name="Powervault Pylontech Min Cell Temperature",
+        source="battery_diagnostics",
+        unique_id_suffix="battery_diagnostics_pylontechMinCellTemperature",
+        child_device_key="battery_diagnostics",
+        child_device_name="Battery Diagnostics",
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        device_class=SensorDeviceClass.TEMPERATURE,
+        precision=1,
+    ),
+    PowervaultExtraSensorDescription(
+        key="pylontechMaxCellTemperature",
+        name="Powervault Pylontech Max Cell Temperature",
+        source="battery_diagnostics",
+        unique_id_suffix="battery_diagnostics_pylontechMaxCellTemperature",
+        child_device_key="battery_diagnostics",
+        child_device_name="Battery Diagnostics",
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        device_class=SensorDeviceClass.TEMPERATURE,
+        precision=1,
+    ),
+    PowervaultExtraSensorDescription(
+        key="pylontechAvgCellTemperature",
+        name="Powervault Pylontech Average Cell Temperature",
+        source="battery_diagnostics",
+        unique_id_suffix="battery_diagnostics_pylontechAvgCellTemperature",
+        child_device_key="battery_diagnostics",
+        child_device_name="Battery Diagnostics",
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        device_class=SensorDeviceClass.TEMPERATURE,
+        precision=1,
+    ),
+    PowervaultExtraSensorDescription(
+        key="pylontechMinBMSTemperature",
+        name="Powervault Pylontech Min BMS Temperature",
+        source="battery_diagnostics",
+        unique_id_suffix="battery_diagnostics_pylontechMinBMSTemperature",
+        child_device_key="battery_diagnostics",
+        child_device_name="Battery Diagnostics",
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        device_class=SensorDeviceClass.TEMPERATURE,
+        precision=1,
+    ),
+    PowervaultExtraSensorDescription(
+        key="pylontechMaxBMSTemperature",
+        name="Powervault Pylontech Max BMS Temperature",
+        source="battery_diagnostics",
+        unique_id_suffix="battery_diagnostics_pylontechMaxBMSTemperature",
+        child_device_key="battery_diagnostics",
+        child_device_name="Battery Diagnostics",
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        device_class=SensorDeviceClass.TEMPERATURE,
+        precision=1,
+    ),
+    PowervaultExtraSensorDescription(
+        key="pylontechAvgBMSTemperature",
+        name="Powervault Pylontech Average BMS Temperature",
+        source="battery_diagnostics",
+        unique_id_suffix="battery_diagnostics_pylontechAvgBMSTemperature",
+        child_device_key="battery_diagnostics",
+        child_device_name="Battery Diagnostics",
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        device_class=SensorDeviceClass.TEMPERATURE,
+        precision=1,
+    ),
+    PowervaultExtraSensorDescription(
+        key="pylontechMinMOSFETTemperature",
+        name="Powervault Pylontech Min MOSFET Temperature",
+        source="battery_diagnostics",
+        unique_id_suffix="battery_diagnostics_pylontechMinMOSFETTemperature",
+        child_device_key="battery_diagnostics",
+        child_device_name="Battery Diagnostics",
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        device_class=SensorDeviceClass.TEMPERATURE,
+        precision=1,
+    ),
+    PowervaultExtraSensorDescription(
+        key="pylontechMaxMOSFETTemperature",
+        name="Powervault Pylontech Max MOSFET Temperature",
+        source="battery_diagnostics",
+        unique_id_suffix="battery_diagnostics_pylontechMaxMOSFETTemperature",
+        child_device_key="battery_diagnostics",
+        child_device_name="Battery Diagnostics",
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        device_class=SensorDeviceClass.TEMPERATURE,
+        precision=1,
+    ),
+    PowervaultExtraSensorDescription(
+        key="pylontechAvgMOSFETTemperature",
+        name="Powervault Pylontech Average MOSFET Temperature",
+        source="battery_diagnostics",
+        unique_id_suffix="battery_diagnostics_pylontechAvgMOSFETTemperature",
+        child_device_key="battery_diagnostics",
+        child_device_name="Battery Diagnostics",
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        device_class=SensorDeviceClass.TEMPERATURE,
+        precision=1,
+    ),
+)
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     config_entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the powerwall sensors."""
-    powervault_data: PowerVault = hass.data[DOMAIN][config_entry.entry_id]
-    coordinator = powervault_data[POWERVAULT_COORDINATOR]
-    assert coordinator is not None
+    powervault_data: PowervaultRuntimeData = hass.data[DOMAIN][config_entry.entry_id]
     entities: list[PowervaultEntity] = [
         PowervaultChargeSensor(powervault_data),
     ]
@@ -111,7 +572,197 @@ async def async_setup_entry(
         _LOGGER.debug(f"Adding sensor {sensor[0]}")
         entities.append(PowervaultPowerSensor(powervault_data, sensor[0], sensor[1]))
 
+    if (platform := config_entry.data.get(CONF_PLATFORM)) in (
+        LEGACY_PLATFORM_P3,
+        LEGACY_PLATFORM_P3X,
+    ):
+        for description in _extra_sensor_descriptions(platform):
+            entities.append(
+                PowervaultExtraTelemetrySensor(powervault_data, description)
+            )
+
+        entities.extend(_build_battery_group_summary_sensors(powervault_data))
+        entities.extend(_build_battery_group_aggregate_sensors(powervault_data))
+
+        if config_entry.options.get(CONF_ENABLE_DETAILED_BATTERY_TELEMETRY, False):
+            entities.extend(_build_detailed_battery_sensors(powervault_data))
+
     async_add_entities(entities)
+
+
+def _extra_sensor_descriptions(
+    platform: str,
+) -> tuple[PowervaultExtraSensorDescription, ...]:
+    """Return additive telemetry sensor descriptions for a stored platform."""
+    if platform == LEGACY_PLATFORM_P3:
+        return (
+            *COMMON_TELEMETRY_SENSORS,
+            *COMMON_BATTERY_DIAGNOSTIC_SENSORS,
+            *P3_BATTERY_DIAGNOSTIC_SENSORS,
+        )
+
+    return (
+        *COMMON_TELEMETRY_SENSORS,
+        *COMMON_BATTERY_DIAGNOSTIC_SENSORS,
+        *P3X_BATTERY_DIAGNOSTIC_SENSORS,
+    )
+
+
+def _build_detailed_battery_sensors(
+    powervault_data: PowervaultRuntimeData,
+) -> list[PowervaultEntity]:
+    """Build per-string or per-module detailed battery sensors."""
+    sensors: list[PowervaultEntity] = []
+    coordinator = powervault_data["coordinator"]
+    assert coordinator is not None
+
+    for child_key, metrics in coordinator.data.detailed_battery.items():
+        for metric_key in metrics:
+            sensors.append(
+                PowervaultDetailedBatterySensor(powervault_data, child_key, metric_key)
+            )
+    return sensors
+
+
+def _build_battery_group_summary_sensors(
+    powervault_data: PowervaultRuntimeData,
+) -> list[PowervaultEntity]:
+    """Build derived voltage summary sensors for each battery group."""
+    sensors: list[PowervaultEntity] = []
+    coordinator = powervault_data["coordinator"]
+    assert coordinator is not None
+
+    for child_key in coordinator.data.detailed_battery:
+        if _group_voltage_summary(coordinator.data.detailed_battery[child_key]) is None:
+            continue
+
+        for summary_key, summary_name in BATTERY_GROUP_SUMMARY_SENSORS:
+            sensors.append(
+                PowervaultBatteryGroupSummarySensor(
+                    powervault_data,
+                    child_key,
+                    summary_key,
+                    summary_name,
+                )
+            )
+
+    return sensors
+
+
+def _build_battery_group_aggregate_sensors(
+    powervault_data: PowervaultRuntimeData,
+) -> list[PowervaultEntity]:
+    """Build shared battery-diagnostics aggregate voltage sensors."""
+    coordinator = powervault_data["coordinator"]
+    assert coordinator is not None
+
+    if _battery_group_voltage_aggregates(coordinator.data.detailed_battery) is None:
+        return []
+
+    return [
+        PowervaultBatteryGroupAggregateSensor(
+            powervault_data, aggregate_key, aggregate_name
+        )
+        for aggregate_key, aggregate_name in BATTERY_GROUP_AGGREGATE_SENSORS
+    ]
+
+
+def _child_label(child_key: str) -> str:
+    """Return the child device label for a detailed battery group."""
+    if child_key.startswith("string"):
+        return f"Battery String {child_key.removeprefix('string')}"
+    if child_key.startswith("pylontechModule"):
+        return f"Battery Module {child_key.removeprefix('pylontechModule')}"
+    return child_key
+
+
+def _detailed_metric_name(metric_key: str) -> str:
+    """Return a readable entity name suffix for a detailed metric key."""
+    lower = metric_key.lower()
+    if "cell" not in metric_key:
+        return metric_key
+
+    cell_index = metric_key.split("cell", maxsplit=1)[1]
+    if cell_index.endswith("Voltage"):
+        return f"Cell {cell_index.removesuffix('Voltage')} Voltage"
+    if cell_index.endswith("Temperature"):
+        return f"Cell {cell_index.removesuffix('Temperature')} Temperature"
+    return metric_key if lower else metric_key
+
+
+def _detailed_metric_unit(metric_key: str) -> str | None:
+    """Return the native unit for a detailed metric key."""
+    if metric_key.endswith("Voltage"):
+        return cast(str, UnitOfElectricPotential.VOLT)
+    if metric_key.endswith("Temperature"):
+        return cast(str, UnitOfTemperature.CELSIUS)
+    return None
+
+
+def _detailed_metric_device_class(metric_key: str) -> SensorDeviceClass | None:
+    """Return the device class for a detailed metric key."""
+    if metric_key.endswith("Voltage"):
+        return SensorDeviceClass.VOLTAGE
+    if metric_key.endswith("Temperature"):
+        return SensorDeviceClass.TEMPERATURE
+    return None
+
+
+def _detailed_metric_precision(metric_key: str) -> int | None:
+    """Return rounding precision for a detailed metric key."""
+    if metric_key.endswith("Voltage"):
+        return 3
+    if metric_key.endswith("Temperature"):
+        return 1
+    return None
+
+
+def _round_value(value: TelemetryValue, precision: int | None) -> TelemetryValue:
+    """Round float telemetry values while leaving other values unchanged."""
+    if isinstance(value, float) and precision is not None:
+        return round(value, precision)
+    if isinstance(value, int) and precision == 0:
+        return value
+    return value
+
+
+def _group_voltage_summary(
+    metrics: dict[str, TelemetryValue],
+) -> dict[str, float] | None:
+    """Return derived voltage summary values for a battery group."""
+    voltage_values = [
+        float(value)
+        for key, value in metrics.items()
+        if key.endswith("Voltage") and isinstance(value, int | float)
+    ]
+
+    if not voltage_values:
+        return None
+
+    return {
+        "total_voltage": round(sum(voltage_values), 3),
+        "average_cell_voltage": round(sum(voltage_values) / len(voltage_values), 3),
+        "maximum_cell_voltage": round(max(voltage_values), 3),
+    }
+
+
+def _battery_group_voltage_aggregates(
+    detailed_battery: dict[str, dict[str, TelemetryValue]],
+) -> dict[str, float] | None:
+    """Return aggregate total-voltage summaries across all battery groups."""
+    total_voltages = [
+        summary["total_voltage"]
+        for metrics in detailed_battery.values()
+        if (summary := _group_voltage_summary(metrics)) is not None
+    ]
+
+    if not total_voltages:
+        return None
+
+    return {
+        "average_total_voltage": round(sum(total_voltages) / len(total_voltages), 3),
+        "maximum_total_voltage": round(max(total_voltages), 3),
+    }
 
 
 class PowervaultChargeSensor(PowervaultEntity, SensorEntity):
@@ -193,3 +844,145 @@ class PowervaultPowerSensor(PowervaultEntity, SensorEntity):
         except (KeyError, TypeError):
             pass
         return None
+
+
+class PowervaultExtraTelemetrySensor(
+    PowervaultEntity, SensorEntity
+):  # pylint: disable=too-many-instance-attributes
+    """Additive local telemetry sensor placed on a child device."""
+
+    def __init__(
+        self,
+        powervault_data: PowervaultRuntimeData,
+        description: PowervaultExtraSensorDescription,
+    ) -> None:
+        """Initialize an additive local telemetry sensor."""
+        super().__init__(powervault_data)
+        self.description = description
+        self._attr_name = description.name
+        self._attr_unique_id = f"{self.base_unique_id}_{description.unique_id_suffix}"
+        self._attr_native_unit_of_measurement = description.native_unit_of_measurement
+        self._attr_device_class = description.device_class
+        self._attr_state_class = description.state_class
+        self._attr_entity_category = description.entity_category
+        self._attr_device_info = self.get_child_device_info(
+            description.child_device_key,
+            description.child_device_name,
+        )
+
+    @property
+    def native_value(self) -> TelemetryValue | None:
+        """Return the current telemetry value for this entity."""
+        source = getattr(self.data, self.description.source)
+        if (value := source.get(self.description.key)) is None:
+            return None
+        if self.description.absolute_value and isinstance(value, int | float):
+            value = abs(value)
+        return _round_value(value, self.description.precision)
+
+
+class PowervaultDetailedBatterySensor(
+    PowervaultEntity, SensorEntity
+):  # pylint: disable=too-many-instance-attributes
+    """Detailed per-string or per-module battery telemetry sensor."""
+
+    _attr_state_class = SensorStateClass.MEASUREMENT
+
+    def __init__(
+        self,
+        powervault_data: PowervaultRuntimeData,
+        child_key: str,
+        metric_key: str,
+    ) -> None:
+        """Initialize a detailed battery telemetry sensor."""
+        super().__init__(powervault_data)
+        self.child_key = child_key
+        self.metric_key = metric_key
+        self.precision = _detailed_metric_precision(metric_key)
+        child_label = _child_label(child_key)
+        self._attr_name = (
+            f"Powervault {child_label} {_detailed_metric_name(metric_key)}"
+        )
+        self._attr_unique_id = f"{self.base_unique_id}_{child_key}_{metric_key}"
+        self._attr_native_unit_of_measurement = _detailed_metric_unit(metric_key)
+        self._attr_device_class = _detailed_metric_device_class(metric_key)
+        self._attr_device_info = self.get_child_device_info(
+            f"battery_{child_key}",
+            child_label,
+        )
+
+    @property
+    def native_value(self) -> TelemetryValue | None:
+        """Return the latest detailed battery telemetry value."""
+        value = self.data.detailed_battery.get(self.child_key, {}).get(self.metric_key)
+        if value is None:
+            return None
+        return _round_value(value, self.precision)
+
+
+class PowervaultBatteryGroupSummarySensor(PowervaultEntity, SensorEntity):
+    """Derived voltage summary sensor for a battery module or string."""
+
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_native_unit_of_measurement = UnitOfElectricPotential.VOLT
+    _attr_device_class = SensorDeviceClass.VOLTAGE
+
+    def __init__(
+        self,
+        powervault_data: PowervaultRuntimeData,
+        child_key: str,
+        summary_key: str,
+        summary_name: str,
+    ) -> None:
+        """Initialize a derived voltage summary sensor."""
+        super().__init__(powervault_data)
+        self.child_key = child_key
+        self.summary_key = summary_key
+        child_label = _child_label(child_key)
+        self._attr_name = f"Powervault {child_label} {summary_name}"
+        self._attr_unique_id = f"{self.base_unique_id}_{child_key}_{summary_key}"
+        self._attr_device_info = self.get_child_device_info(
+            "battery_diagnostics",
+            "Battery Diagnostics",
+        )
+
+    @property
+    def native_value(self) -> float | None:
+        """Return the derived voltage summary value."""
+        metrics = self.data.detailed_battery.get(self.child_key, {})
+        if (summary := _group_voltage_summary(metrics)) is None:
+            return None
+        return summary[self.summary_key]
+
+
+class PowervaultBatteryGroupAggregateSensor(PowervaultEntity, SensorEntity):
+    """Shared battery-diagnostics aggregate sensor derived from group voltages."""
+
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_native_unit_of_measurement = UnitOfElectricPotential.VOLT
+    _attr_device_class = SensorDeviceClass.VOLTAGE
+
+    def __init__(
+        self,
+        powervault_data: PowervaultRuntimeData,
+        aggregate_key: str,
+        aggregate_name: str,
+    ) -> None:
+        """Initialize an aggregate voltage summary sensor."""
+        super().__init__(powervault_data)
+        self.aggregate_key = aggregate_key
+        self._attr_name = f"Powervault {aggregate_name}"
+        self._attr_unique_id = f"{self.base_unique_id}_{aggregate_key}"
+        self._attr_device_info = self.get_child_device_info(
+            "battery_diagnostics",
+            "Battery Diagnostics",
+        )
+
+    @property
+    def native_value(self) -> float | None:
+        """Return the shared aggregate voltage summary value."""
+        if (
+            aggregates := _battery_group_voltage_aggregates(self.data.detailed_battery)
+        ) is None:
+            return None
+        return aggregates[self.aggregate_key]

--- a/custom_components/powervault/strings.json
+++ b/custom_components/powervault/strings.json
@@ -59,7 +59,8 @@
       "init": {
         "title": "Powervault P3 options",
         "data": {
-          "poll_interval": "Polling interval (seconds)"
+          "poll_interval": "Polling interval (seconds)",
+          "enable_detailed_battery_telemetry": "Enable detailed battery telemetry"
         }
       }
     }

--- a/custom_components/powervault/switch.py
+++ b/custom_components/powervault/switch.py
@@ -25,7 +25,9 @@ async def async_setup_entry(
         async_add_entities([PowervaultHistorySwitch(powervault_data)])
 
 
-class PowervaultHistorySwitch(PowervaultEntity, SwitchEntity):
+class PowervaultHistorySwitch(  # pylint: disable=abstract-method
+    PowervaultEntity, SwitchEntity
+):
     """Switch to enable/disable API history collection for energy totals.
 
     When on (default), each poll attempts to fetch today's chart history from

--- a/custom_components/powervault/translations/en.json
+++ b/custom_components/powervault/translations/en.json
@@ -59,7 +59,8 @@
       "init": {
         "title": "Powervault P3 options",
         "data": {
-          "poll_interval": "Polling interval (seconds)"
+          "poll_interval": "Polling interval (seconds)",
+          "enable_detailed_battery_telemetry": "Enable detailed battery telemetry"
         }
       }
     }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-powervaultpy==1.1.0
+powervaultpy==1.1.5

--- a/tests/example-telemetry.json
+++ b/tests/example-telemetry.json
@@ -1,0 +1,2698 @@
+[
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "actualState",
+    "timestamp": 1783163451.892468,
+    "unit": "I|C",
+    "value": "C"
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "aux1Power",
+    "timestamp": 1783163451.892468,
+    "unit": "watts",
+    "value": -1404
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "aux2Power",
+    "timestamp": 1783163451.892468,
+    "unit": "watts",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "aux3Power",
+    "timestamp": 1783163451.892468,
+    "unit": "watts",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "backplane0Temperature",
+    "timestamp": 1783163451.892468,
+    "unit": "celsius",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "backplane1Temperature",
+    "timestamp": 1783163451.892468,
+    "unit": "celsius",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "backplane2Temperature",
+    "timestamp": 1783163451.892468,
+    "unit": "celsius",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "backplane3Temperature",
+    "timestamp": 1783163451.892468,
+    "unit": "celsius",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "backplane4Temperature",
+    "timestamp": 1783163451.892468,
+    "unit": "celsius",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "batteryCurrent",
+    "timestamp": 1783163451.892468,
+    "unit": "A",
+    "value": 2.4500000000000002
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "batteryPower",
+    "timestamp": 1783163451.892468,
+    "unit": "watts",
+    "value": 846
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "cpuTemperature",
+    "timestamp": 1783163451.892468,
+    "unit": "celsius",
+    "value": 56.0
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "gridCurrent",
+    "timestamp": 1783163451.892468,
+    "unit": "A",
+    "value": 3.3799999999999999
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "gridPower",
+    "timestamp": 1783163451.892468,
+    "unit": "watts",
+    "value": -36
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "inverterFrequency",
+    "timestamp": 1783163451.892468,
+    "unit": "Hz",
+    "value": 50.0
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "inverterVoltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 218.69999999999999
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "maxChargePower",
+    "timestamp": 1783163451.892468,
+    "unit": "W",
+    "value": 11981
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "maxDischargePower",
+    "timestamp": 1783163451.892468,
+    "unit": "W",
+    "value": 10125
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pack0Temperature",
+    "timestamp": 1783163451.892468,
+    "unit": "celsius",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pack1Temperature",
+    "timestamp": 1783163451.892468,
+    "unit": "celsius",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pack2Temperature",
+    "timestamp": 1783163451.892468,
+    "unit": "celsius",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pack3Temperature",
+    "timestamp": 1783163451.892468,
+    "unit": "celsius",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pack4Temperature",
+    "timestamp": 1783163451.892468,
+    "unit": "celsius",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pack5Temperature",
+    "timestamp": 1783163451.892468,
+    "unit": "celsius",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pack6Temperature",
+    "timestamp": 1783163451.892468,
+    "unit": "celsius",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pack7Temperature",
+    "timestamp": 1783163451.892468,
+    "unit": "celsius",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pack8Temperature",
+    "timestamp": 1783163451.892468,
+    "unit": "celsius",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pack9Temperature",
+    "timestamp": 1783163451.892468,
+    "unit": "celsius",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechAvgBMSTemperature",
+    "timestamp": 1783163451.892468,
+    "unit": "celsius",
+    "value": 24.699999999999999
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechAvgCellTemperature",
+    "timestamp": 1783163451.892468,
+    "unit": "celsius",
+    "value": 22.300000000000001
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechAvgMOSFETTemperature",
+    "timestamp": 1783163451.892468,
+    "unit": "celsius",
+    "value": 23.699999999999999
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechMaxBMSTemperature",
+    "timestamp": 1783163451.892468,
+    "unit": "celsius",
+    "value": 26.0
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechMaxCellTemperature",
+    "timestamp": 1783163451.892468,
+    "unit": "celsius",
+    "value": 23.399999999999999
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechMaxCellVoltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.3380000000000001
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechMaxMOSFETTemperature",
+    "timestamp": 1783163451.892468,
+    "unit": "celsius",
+    "value": 24.800000000000001
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechMinBMSTemperature",
+    "timestamp": 1783163451.892468,
+    "unit": "celsius",
+    "value": 23.800000000000001
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechMinCellTemperature",
+    "timestamp": 1783163451.892468,
+    "unit": "celsius",
+    "value": 21.300000000000001
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechMinCellVoltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.3199999999999998
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechMinMOSFETTemperature",
+    "timestamp": 1783163451.892468,
+    "unit": "celsius",
+    "value": 23.100000000000001
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule10cell0Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.3359999999999999
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule10cell10Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.3380000000000001
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule10cell11Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.3330000000000002
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule10cell12Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.335
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule10cell13Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.3370000000000002
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule10cell14Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.3370000000000002
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule10cell1Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.3340000000000001
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule10cell2Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.3330000000000002
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule10cell3Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.3359999999999999
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule10cell4Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.3370000000000002
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule10cell5Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.3340000000000001
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule10cell6Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.3330000000000002
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule10cell7Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.3330000000000002
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule10cell8Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.3359999999999999
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule10cell9Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.3340000000000001
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule11cell0Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule11cell10Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule11cell11Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule11cell12Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule11cell13Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule11cell14Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule11cell1Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule11cell2Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule11cell3Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule11cell4Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule11cell5Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule11cell6Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule11cell7Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule11cell8Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule11cell9Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule2cell0Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.3290000000000002
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule2cell10Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.3279999999999998
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule2cell11Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.3279999999999998
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule2cell12Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.3279999999999998
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule2cell13Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.327
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule2cell14Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.327
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule2cell1Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.327
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule2cell2Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.327
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule2cell3Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.327
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule2cell4Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.3279999999999998
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule2cell5Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.3279999999999998
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule2cell6Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.327
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule2cell7Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.327
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule2cell8Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.327
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule2cell9Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.3290000000000002
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule3cell0Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.3250000000000002
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule3cell10Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.3260000000000001
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule3cell11Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.3279999999999998
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule3cell12Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.3239999999999998
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule3cell13Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.3290000000000002
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule3cell14Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.3300000000000001
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule3cell1Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.3279999999999998
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule3cell2Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.3279999999999998
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule3cell3Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.3250000000000002
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule3cell4Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.3260000000000001
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule3cell5Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.3239999999999998
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule3cell6Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.323
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule3cell7Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.3239999999999998
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule3cell8Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.3239999999999998
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule3cell9Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.3260000000000001
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule4cell0Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.335
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule4cell10Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.335
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule4cell11Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.3359999999999999
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule4cell12Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.3340000000000001
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule4cell13Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.3359999999999999
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule4cell14Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.335
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule4cell1Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.3330000000000002
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule4cell2Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.3340000000000001
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule4cell3Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.3330000000000002
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule4cell4Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.3340000000000001
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule4cell5Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.3359999999999999
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule4cell6Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.335
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule4cell7Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.335
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule4cell8Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.335
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule4cell9Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.3399999999999999
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule5cell0Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.335
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule5cell10Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.3340000000000001
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule5cell11Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.3359999999999999
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule5cell12Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.3340000000000001
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule5cell13Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.3330000000000002
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule5cell14Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.335
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule5cell1Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.3340000000000001
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule5cell2Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.3340000000000001
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule5cell3Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.3330000000000002
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule5cell4Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.3359999999999999
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule5cell5Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.335
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule5cell6Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.3340000000000001
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule5cell7Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.3359999999999999
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule5cell8Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.3330000000000002
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule5cell9Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.3340000000000001
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule6cell0Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.3340000000000001
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule6cell10Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.3330000000000002
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule6cell11Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.3340000000000001
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule6cell12Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.3319999999999999
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule6cell13Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.335
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule6cell14Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.3359999999999999
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule6cell1Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.3380000000000001
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule6cell2Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.3399999999999999
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule6cell3Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.3370000000000002
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule6cell4Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.3370000000000002
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule6cell5Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.3340000000000001
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule6cell6Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.331
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule6cell7Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.331
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule6cell8Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.335
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule6cell9Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.331
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule7cell0Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.335
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule7cell10Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.3359999999999999
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule7cell11Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.3340000000000001
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule7cell12Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.3359999999999999
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule7cell13Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.3359999999999999
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule7cell14Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.3359999999999999
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule7cell1Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.335
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule7cell2Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.3319999999999999
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule7cell3Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.335
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule7cell4Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.335
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule7cell5Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.3359999999999999
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule7cell6Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.3330000000000002
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule7cell7Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.335
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule7cell8Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.3340000000000001
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule7cell9Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.335
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule8cell0Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.331
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule8cell10Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.3330000000000002
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule8cell11Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.3340000000000001
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule8cell12Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.3330000000000002
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule8cell13Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.3340000000000001
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule8cell14Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.3330000000000002
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule8cell1Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.3330000000000002
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule8cell2Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.3330000000000002
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule8cell3Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.3319999999999999
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule8cell4Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.331
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule8cell5Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.3330000000000002
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule8cell6Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.3330000000000002
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule8cell7Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.3330000000000002
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule8cell8Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.331
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule8cell9Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.3319999999999999
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule9cell0Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.3319999999999999
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule9cell10Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.331
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule9cell11Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.3290000000000002
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule9cell12Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.3340000000000001
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule9cell13Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.3399999999999999
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule9cell14Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.3290000000000002
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule9cell1Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.327
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule9cell2Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.327
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule9cell3Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.343
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule9cell4Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.3300000000000001
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule9cell5Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.331
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule9cell6Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.327
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule9cell7Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.331
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule9cell8Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.3290000000000002
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "pylontechModule9cell9Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": 3.339
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "requestedState",
+    "timestamp": 1783163451.892468,
+    "unit": "N|I|C|V|H|L|F|R|D|P|Q|A|B|T",
+    "value": "N"
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "socAverage",
+    "timestamp": 1783163451.892468,
+    "unit": "percent",
+    "value": 58
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "socUsable",
+    "timestamp": 1783163451.892468,
+    "unit": "percent",
+    "value": 55
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string0cell0Temperature",
+    "timestamp": 1783163451.892468,
+    "unit": "celsius",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string0cell0Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string0cell10Temperature",
+    "timestamp": 1783163451.892468,
+    "unit": "celsius",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string0cell10Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string0cell11Temperature",
+    "timestamp": 1783163451.892468,
+    "unit": "celsius",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string0cell11Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string0cell12Temperature",
+    "timestamp": 1783163451.892468,
+    "unit": "celsius",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string0cell12Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string0cell13Temperature",
+    "timestamp": 1783163451.892468,
+    "unit": "celsius",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string0cell13Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string0cell1Temperature",
+    "timestamp": 1783163451.892468,
+    "unit": "celsius",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string0cell1Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string0cell2Temperature",
+    "timestamp": 1783163451.892468,
+    "unit": "celsius",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string0cell2Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string0cell3Temperature",
+    "timestamp": 1783163451.892468,
+    "unit": "celsius",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string0cell3Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string0cell4Temperature",
+    "timestamp": 1783163451.892468,
+    "unit": "celsius",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string0cell4Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string0cell5Temperature",
+    "timestamp": 1783163451.892468,
+    "unit": "celsius",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string0cell5Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string0cell6Temperature",
+    "timestamp": 1783163451.892468,
+    "unit": "celsius",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string0cell6Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string0cell7Temperature",
+    "timestamp": 1783163451.892468,
+    "unit": "celsius",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string0cell7Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string0cell8Temperature",
+    "timestamp": 1783163451.892468,
+    "unit": "celsius",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string0cell8Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string0cell9Temperature",
+    "timestamp": 1783163451.892468,
+    "unit": "celsius",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string0cell9Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string1cell0Temperature",
+    "timestamp": 1783163451.892468,
+    "unit": "celsius",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string1cell0Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string1cell10Temperature",
+    "timestamp": 1783163451.892468,
+    "unit": "celsius",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string1cell10Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string1cell11Temperature",
+    "timestamp": 1783163451.892468,
+    "unit": "celsius",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string1cell11Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string1cell12Temperature",
+    "timestamp": 1783163451.892468,
+    "unit": "celsius",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string1cell12Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string1cell13Temperature",
+    "timestamp": 1783163451.892468,
+    "unit": "celsius",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string1cell13Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string1cell1Temperature",
+    "timestamp": 1783163451.892468,
+    "unit": "celsius",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string1cell1Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string1cell2Temperature",
+    "timestamp": 1783163451.892468,
+    "unit": "celsius",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string1cell2Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string1cell3Temperature",
+    "timestamp": 1783163451.892468,
+    "unit": "celsius",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string1cell3Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string1cell4Temperature",
+    "timestamp": 1783163451.892468,
+    "unit": "celsius",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string1cell4Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string1cell5Temperature",
+    "timestamp": 1783163451.892468,
+    "unit": "celsius",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string1cell5Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string1cell6Temperature",
+    "timestamp": 1783163451.892468,
+    "unit": "celsius",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string1cell6Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string1cell7Temperature",
+    "timestamp": 1783163451.892468,
+    "unit": "celsius",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string1cell7Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string1cell8Temperature",
+    "timestamp": 1783163451.892468,
+    "unit": "celsius",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string1cell8Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string1cell9Temperature",
+    "timestamp": 1783163451.892468,
+    "unit": "celsius",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string1cell9Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string2cell0Temperature",
+    "timestamp": 1783163451.892468,
+    "unit": "celsius",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string2cell0Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string2cell10Temperature",
+    "timestamp": 1783163451.892468,
+    "unit": "celsius",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string2cell10Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string2cell11Temperature",
+    "timestamp": 1783163451.892468,
+    "unit": "celsius",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string2cell11Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string2cell12Temperature",
+    "timestamp": 1783163451.892468,
+    "unit": "celsius",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string2cell12Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string2cell13Temperature",
+    "timestamp": 1783163451.892468,
+    "unit": "celsius",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string2cell13Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string2cell1Temperature",
+    "timestamp": 1783163451.892468,
+    "unit": "celsius",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string2cell1Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string2cell2Temperature",
+    "timestamp": 1783163451.892468,
+    "unit": "celsius",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string2cell2Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string2cell3Temperature",
+    "timestamp": 1783163451.892468,
+    "unit": "celsius",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string2cell3Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string2cell4Temperature",
+    "timestamp": 1783163451.892468,
+    "unit": "celsius",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string2cell4Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string2cell5Temperature",
+    "timestamp": 1783163451.892468,
+    "unit": "celsius",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string2cell5Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string2cell6Temperature",
+    "timestamp": 1783163451.892468,
+    "unit": "celsius",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string2cell6Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string2cell7Temperature",
+    "timestamp": 1783163451.892468,
+    "unit": "celsius",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string2cell7Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string2cell8Temperature",
+    "timestamp": 1783163451.892468,
+    "unit": "celsius",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string2cell8Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string2cell9Temperature",
+    "timestamp": 1783163451.892468,
+    "unit": "celsius",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string2cell9Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string3cell0Temperature",
+    "timestamp": 1783163451.892468,
+    "unit": "celsius",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string3cell0Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string3cell10Temperature",
+    "timestamp": 1783163451.892468,
+    "unit": "celsius",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string3cell10Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string3cell11Temperature",
+    "timestamp": 1783163451.892468,
+    "unit": "celsius",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string3cell11Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string3cell12Temperature",
+    "timestamp": 1783163451.892468,
+    "unit": "celsius",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string3cell12Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string3cell13Temperature",
+    "timestamp": 1783163451.892468,
+    "unit": "celsius",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string3cell13Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string3cell1Temperature",
+    "timestamp": 1783163451.892468,
+    "unit": "celsius",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string3cell1Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string3cell2Temperature",
+    "timestamp": 1783163451.892468,
+    "unit": "celsius",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string3cell2Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string3cell3Temperature",
+    "timestamp": 1783163451.892468,
+    "unit": "celsius",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string3cell3Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string3cell4Temperature",
+    "timestamp": 1783163451.892468,
+    "unit": "celsius",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string3cell4Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string3cell5Temperature",
+    "timestamp": 1783163451.892468,
+    "unit": "celsius",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string3cell5Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string3cell6Temperature",
+    "timestamp": 1783163451.892468,
+    "unit": "celsius",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string3cell6Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string3cell7Temperature",
+    "timestamp": 1783163451.892468,
+    "unit": "celsius",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string3cell7Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string3cell8Temperature",
+    "timestamp": 1783163451.892468,
+    "unit": "celsius",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string3cell8Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string3cell9Temperature",
+    "timestamp": 1783163451.892468,
+    "unit": "celsius",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string3cell9Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string4cell0Temperature",
+    "timestamp": 1783163451.892468,
+    "unit": "celsius",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string4cell0Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string4cell10Temperature",
+    "timestamp": 1783163451.892468,
+    "unit": "celsius",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string4cell10Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string4cell11Temperature",
+    "timestamp": 1783163451.892468,
+    "unit": "celsius",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string4cell11Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string4cell12Temperature",
+    "timestamp": 1783163451.892468,
+    "unit": "celsius",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string4cell12Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string4cell13Temperature",
+    "timestamp": 1783163451.892468,
+    "unit": "celsius",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string4cell13Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string4cell1Temperature",
+    "timestamp": 1783163451.892468,
+    "unit": "celsius",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string4cell1Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string4cell2Temperature",
+    "timestamp": 1783163451.892468,
+    "unit": "celsius",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string4cell2Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string4cell3Temperature",
+    "timestamp": 1783163451.892468,
+    "unit": "celsius",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string4cell3Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string4cell4Temperature",
+    "timestamp": 1783163451.892468,
+    "unit": "celsius",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string4cell4Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string4cell5Temperature",
+    "timestamp": 1783163451.892468,
+    "unit": "celsius",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string4cell5Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string4cell6Temperature",
+    "timestamp": 1783163451.892468,
+    "unit": "celsius",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string4cell6Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string4cell7Temperature",
+    "timestamp": 1783163451.892468,
+    "unit": "celsius",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string4cell7Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string4cell8Temperature",
+    "timestamp": 1783163451.892468,
+    "unit": "celsius",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string4cell8Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string4cell9Temperature",
+    "timestamp": 1783163451.892468,
+    "unit": "celsius",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "string4cell9Voltage",
+    "timestamp": 1783163451.892468,
+    "unit": "V",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "temperature",
+    "timestamp": 1783163451.892468,
+    "unit": "celsius",
+    "value": 32.0
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "vocCO2",
+    "timestamp": 1783163451.892468,
+    "unit": "ppm",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "vocHumidity",
+    "timestamp": 1783163451.892468,
+    "unit": "percent",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "vocTemperature",
+    "timestamp": 1783163451.892468,
+    "unit": "celsius",
+    "value": null
+  },
+  {
+    "created_at": 1783163451.892468,
+    "id": null,
+    "measurement": "vocVOC",
+    "timestamp": 1783163451.892468,
+    "unit": "index",
+    "value": null
+  }
+]

--- a/tests/test_daily_totals.py
+++ b/tests/test_daily_totals.py
@@ -35,6 +35,9 @@ def _make_data() -> PowervaultData:
         instant_solar=0,
         battery_state="normal",
         totals={},
+        common_telemetry={},
+        battery_diagnostics={},
+        detailed_battery={},
     )
 
 

--- a/tests/test_daily_totals.py
+++ b/tests/test_daily_totals.py
@@ -1,0 +1,147 @@
+"""Regression tests for Powervault daily totals."""
+
+# pylint: disable=protected-access
+
+from __future__ import annotations
+
+import asyncio
+from datetime import date
+from datetime import datetime as real_dt
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock, patch
+from zoneinfo import ZoneInfo
+
+from custom_components.powervault import PowervaultDataManager, _try_fetch_chart_totals
+from custom_components.powervault.models import PowervaultData
+
+
+def _make_data() -> PowervaultData:
+    """Build a zeroed PowervaultData sample for accumulator tests."""
+    return PowervaultData(
+        charge=80,
+        batteryInputFromGrid=0,
+        batteryInputFromSolar=0,
+        batteryOutputConsumedByHome=0,
+        batteryOutputExported=0,
+        homeConsumed=0,
+        gridConsumedByHome=0,
+        solarConsumedByHome=0,
+        solarExported=0,
+        instant_battery=0,
+        instant_demand=0,
+        instant_grid=0,
+        solarGenerated=0,
+        solarConsumption=0,
+        instant_solar=0,
+        battery_state="normal",
+        totals={},
+    )
+
+
+def _make_manager(time_zone: str) -> PowervaultDataManager:
+    """Build a minimally initialized data manager for unit tests."""
+    manager = object.__new__(PowervaultDataManager)
+    manager.hass = SimpleNamespace(config=SimpleNamespace(time_zone=time_zone))
+    manager.client = Mock()
+    manager.unit_id = None
+    manager.local_ip = "192.168.0.10"
+    manager.runtime_data = {}
+    manager.config_entry = None
+    manager._local_tz = ZoneInfo(time_zone)
+    manager._acc = dict.fromkeys(PowervaultDataManager._TOTAL_KEYS, 12.0)
+    manager._last_poll_time = None
+    manager._acc_date = date(2026, 6, 10)
+    manager._store = None
+    return manager
+
+
+def test_accumulate_resets_at_homeassistant_midnight() -> None:
+    """Reset should follow Home Assistant's configured timezone."""
+    manager = _make_manager("Europe/Helsinki")
+    manager._last_poll_time = real_dt(2026, 6, 10, 23, 55, tzinfo=manager._local_tz)
+    now_local = real_dt(2026, 6, 11, 0, 5, tzinfo=manager._local_tz)
+
+    with patch("custom_components.powervault.dt", wraps=real_dt) as mock_dt:
+        mock_dt.now.return_value = now_local
+        result = manager._accumulate(_make_data(), api_totals=None)
+
+    assert manager._acc_date == date(2026, 6, 11)
+    assert result.totals["solarGenerated"] == 0.0
+    assert result.totals["homeConsumed"] == 0.0
+
+
+def test_try_fetch_chart_totals_discards_previous_day_samples() -> None:
+    """Previous-day chart samples must not seed a new day's totals."""
+    local_tz = ZoneInfo("Europe/London")
+    stale_sample_time = real_dt(2026, 6, 30, 23, 55, tzinfo=local_tz).timestamp()
+    client = Mock()
+    client.get_chart_data.return_value = [
+        [
+            {
+                "measurement": "gridPower",
+                "timestamp": stale_sample_time,
+                "value": 0,
+            },
+            {
+                "measurement": "batteryPower",
+                "timestamp": stale_sample_time,
+                "value": 0,
+            },
+            {
+                "measurement": "aux1Power",
+                "timestamp": stale_sample_time,
+                "value": -2000,
+            },
+        ]
+    ]
+
+    with patch("custom_components.powervault.dt", wraps=real_dt) as mock_dt:
+        mock_dt.now.return_value = real_dt(2026, 7, 1, 0, 2, tzinfo=local_tz)
+        totals = _try_fetch_chart_totals(client, local_tz)
+
+    assert totals is None
+
+
+def test_try_fetch_chart_totals_handles_flat_chart_samples() -> None:
+    """Flat chart-data samples from the client library should be accepted."""
+    local_tz = ZoneInfo("Europe/London")
+    client = Mock()
+    client.get_chart_data.return_value = [
+        {
+            "timestamp": real_dt(2026, 7, 1, 0, 5, tzinfo=local_tz).timestamp(),
+            "gridPower": 120,
+            "batteryPower": 0,
+            "aux1Power": 0,
+        },
+        {
+            "timestamp": real_dt(2026, 7, 1, 0, 10, tzinfo=local_tz).timestamp(),
+            "gridPower": 150,
+            "batteryPower": 0,
+            "aux1Power": 0,
+        },
+    ]
+
+    with patch("custom_components.powervault.dt", wraps=real_dt) as mock_dt:
+        mock_dt.now.return_value = real_dt(2026, 7, 1, 0, 10, tzinfo=local_tz)
+        totals = _try_fetch_chart_totals(client, local_tz)
+
+    assert totals is not None
+    assert totals["solarGenerated"] == 0.0
+    assert totals["gridConsumedByHome"] > 0.0
+
+
+def test_async_reset_cached_totals_clears_accumulator_and_store() -> None:
+    """Manual reset should clear both in-memory and persisted accumulator state."""
+    manager = _make_manager("Europe/London")
+    manager._acc["solarGenerated"] = 12.5
+    manager._last_poll_time = real_dt(2026, 7, 1, 1, 0, tzinfo=manager._local_tz)
+    manager._store = AsyncMock()
+
+    with patch("custom_components.powervault.dt", wraps=real_dt) as mock_dt:
+        mock_dt.now.return_value = real_dt(2026, 7, 1, 1, 20, tzinfo=manager._local_tz)
+        asyncio.run(manager.async_reset_cached_totals())
+
+    assert manager._acc["solarGenerated"] == 0.0
+    assert manager._last_poll_time is None
+    assert manager._acc_date == date(2026, 7, 1)
+    manager._store.async_remove.assert_awaited_once()

--- a/tests/test_local_telemetry.py
+++ b/tests/test_local_telemetry.py
@@ -29,12 +29,7 @@ from custom_components.powervault.sensor import (
 
 def _load_example_telemetry() -> list[dict[str, object]]:
     """Load the checked-in P3X telemetry sample."""
-    fixture_path = (
-        Path(__file__).resolve().parents[1]
-        / "custom_components"
-        / "powervault"
-        / "example-telemetry.json"
-    )
+    fixture_path = Path(__file__).resolve().parents[0] / "example-telemetry.json"
     return cast(
         list[dict[str, object]],
         json.loads(fixture_path.read_text(encoding="utf-8")),

--- a/tests/test_local_telemetry.py
+++ b/tests/test_local_telemetry.py
@@ -1,0 +1,162 @@
+"""Unit tests for Powervault local telemetry parsing and platform persistence."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import Callable
+from pathlib import Path
+from types import SimpleNamespace
+from typing import cast
+from unittest.mock import Mock
+
+from custom_components.powervault import (
+    _async_ensure_legacy_platform,
+    _fetch_base_info_legacy,
+    _fetch_powervault_data_legacy,
+)
+from custom_components.powervault.const import (
+    CONF_IP_ADDRESS,
+    CONF_PLATFORM,
+    LEGACY_PLATFORM_P3,
+    LEGACY_PLATFORM_P3X,
+)
+from custom_components.powervault.sensor import (
+    _battery_group_voltage_aggregates,
+    _group_voltage_summary,
+)
+
+
+def _load_example_telemetry() -> list[dict[str, object]]:
+    """Load the checked-in P3X telemetry sample."""
+    fixture_path = (
+        Path(__file__).resolve().parents[1]
+        / "custom_components"
+        / "powervault"
+        / "example-telemetry.json"
+    )
+    return cast(
+        list[dict[str, object]],
+        json.loads(fixture_path.read_text(encoding="utf-8")),
+    )
+
+
+def test_fetch_powervault_data_legacy_p3x_parses_common_and_battery_telemetry() -> None:
+    """P3X local telemetry should populate additive telemetry buckets."""
+    client = Mock()
+    client.get_data.return_value = _load_example_telemetry()
+    client.get_battery_state.return_value = "normal"
+
+    data = _fetch_powervault_data_legacy(client, LEGACY_PLATFORM_P3X)
+
+    assert data.charge == 55
+    assert data.common_telemetry["gridCurrent"] == 3.3799999999999999
+    assert data.common_telemetry["maxChargePower"] == 11981
+    assert data.battery_diagnostics["socAverage"] == 58
+    assert data.battery_diagnostics["pylontechMaxCellVoltage"] == 3.3380000000000001
+    assert "pylontechModule10" in data.detailed_battery
+    assert (
+        data.detailed_battery["pylontechModule10"]["pylontechModule10cell0Voltage"]
+        == 3.3359999999999999
+    )
+
+    module_summary = _group_voltage_summary(data.detailed_battery["pylontechModule10"])
+    assert module_summary == {
+        "total_voltage": 50.026,
+        "average_cell_voltage": 3.335,
+        "maximum_cell_voltage": 3.338,
+    }
+
+    aggregate_summary = _battery_group_voltage_aggregates(data.detailed_battery)
+    assert aggregate_summary == {
+        "average_total_voltage": 49.987,
+        "maximum_total_voltage": 50.026,
+    }
+
+
+def test_fetch_powervault_data_legacy_p3_derives_summary_metrics() -> None:
+    """P3 local telemetry should derive pack, backplane, and string summaries."""
+    client = Mock()
+    client.get_data.return_value = [
+        {"measurement": "socUsable", "value": 64},
+        {"measurement": "socAverage", "value": 66},
+        {"measurement": "gridPower", "value": 250},
+        {"measurement": "batteryPower", "value": -400},
+        {"measurement": "aux1Power", "value": -900},
+        {"measurement": "pack0Temperature", "value": 21.2},
+        {"measurement": "pack1Temperature", "value": 26.7},
+        {"measurement": "backplane0Temperature", "value": 19.4},
+        {"measurement": "backplane1Temperature", "value": 22.8},
+        {"measurement": "string0cell0Voltage", "value": 3.301},
+        {"measurement": "string0cell1Voltage", "value": 3.315},
+        {"measurement": "string1cell0Voltage", "value": 3.289},
+        {"measurement": "string0cell0Temperature", "value": 22.4},
+        {"measurement": "string0cell1Temperature", "value": 23.1},
+        {"measurement": "string1cell0Temperature", "value": 24.9},
+    ]
+    client.get_battery_state.return_value = "normal"
+
+    data = _fetch_powervault_data_legacy(client, LEGACY_PLATFORM_P3)
+
+    assert data.battery_diagnostics["socAverage"] == 66
+    assert data.battery_diagnostics["pack_temperature_min"] == 21.2
+    assert data.battery_diagnostics["pack_temperature_max"] == 26.7
+    assert data.battery_diagnostics["pack_temperature_avg"] == 23.9
+    assert data.battery_diagnostics["backplane_temperature_avg"] == 21.1
+    assert data.battery_diagnostics["string_cell_voltage_min"] == 3.289
+    assert data.battery_diagnostics["string_cell_voltage_max"] == 3.315
+    assert data.battery_diagnostics["string_cell_voltage_avg"] == 3.302
+    assert data.battery_diagnostics["string_cell_temperature_avg"] == 23.5
+    assert "string0" in data.detailed_battery
+    assert data.detailed_battery["string0"]["string0cell1Voltage"] == 3.315
+
+    string_summary = _group_voltage_summary(data.detailed_battery["string0"])
+    assert string_summary == {
+        "total_voltage": 6.616,
+        "average_cell_voltage": 3.308,
+        "maximum_cell_voltage": 3.315,
+    }
+
+    aggregate_summary = _battery_group_voltage_aggregates(data.detailed_battery)
+    assert aggregate_summary == {
+        "average_total_voltage": 4.952,
+        "maximum_total_voltage": 6.616,
+    }
+
+
+def test_async_ensure_legacy_platform_persists_detected_value() -> None:
+    """Legacy local platform should be detected once and stored in config data."""
+
+    async def async_add_executor_job(func: Callable[..., str], *args: object) -> str:
+        return func(*args)
+
+    update_entry = Mock()
+    hass = SimpleNamespace(
+        async_add_executor_job=async_add_executor_job,
+        config_entries=SimpleNamespace(async_update_entry=update_entry),
+    )
+    entry = SimpleNamespace(data={CONF_IP_ADDRESS: "192.168.0.20"})
+    client = Mock()
+    client.get_platform.return_value = "P3X"
+
+    platform = asyncio.run(_async_ensure_legacy_platform(hass, entry, client))
+
+    assert platform == LEGACY_PLATFORM_P3X
+    update_entry.assert_called_once_with(
+        entry,
+        data={
+            CONF_IP_ADDRESS: "192.168.0.20",
+            CONF_PLATFORM: LEGACY_PLATFORM_P3X,
+        },
+    )
+
+
+def test_fetch_base_info_legacy_uses_uppercase_platform_as_model() -> None:
+    """Legacy local device model should match the stored platform in uppercase."""
+    client = Mock()
+    client.get_unit_id.return_value = "pv-site-1"
+
+    base_info = _fetch_base_info_legacy(client, LEGACY_PLATFORM_P3X)
+
+    assert base_info.id == "pv-site-1"
+    assert base_info.model == "Powervault P3X"


### PR DESCRIPTION
Added extra telemetry collection

### Changed

- Bumped `powervaultpy` to `v1.1.5`
- **Legacy local units now identify themselves more accurately.** The integration now detects whether a local Powervault is a `P3` or `P3X`, this is used to determine which battery sensors to read. The Home Assistant device model for local units now reflects the detected platform, for example `Powervault P3X`.

### Added

- **Expanded local telemetry for P3 and P3X units.** Local API users now get additional diagnostic sensors for inverter, current, temperature, battery health, and VOC sensor (not available for P3X units) data where the Powervault reports it.
- **New "Battery Diagnostics" child device.** Additional battery-health sensors are now grouped under a separate child device to avoid cluttering the main Powervault device.
- **P3X battery summary sensors.** P3X users now get summary battery diagnostics such as minimum and maximum cell voltage, minimum/maximum/average cell temperature, and minimum/maximum/average BMS and MOSFET temperatures.
- **P3 battery summary sensors.** Legacy P3 users now get derived summary sensors for pack temperature, backplane temperature, and string cell voltage and temperature.
- **Battery module total voltage sensors.** Local units now expose derived total-voltage sensors for each battery module or string on the Battery Diagnostics device. Two additional aggregate sensors are also provided by default: average battery module total voltage and maximum battery module total voltage.
- **Optional detailed battery telemetry.** A new **Configure** option for local units lets advanced users enable detailed per-cell battery telemetry when needed. This create a unique device per battery module with it's own per-cell telemetry.